### PR TITLE
Add account edit page and not-found handling

### DIFF
--- a/src/app/accounts/[id]/edit/page.tsx
+++ b/src/app/accounts/[id]/edit/page.tsx
@@ -1,0 +1,60 @@
+import { db } from "@/lib/db";
+import { getCurrentUser } from "@/lib/auth";
+import { AccountForm } from "@/components/account-form";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+export const metadata = {
+  title: "Edit Account — CoinKeeper",
+};
+
+export default async function EditAccountPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await getCurrentUser();
+  const { id } = await params;
+
+  const account = await db.account.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!account) {
+    notFound();
+  }
+
+  return (
+    <main className="flex-1 w-full max-w-xl mx-auto px-4 py-8">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 mb-6">
+        <Link
+          href="/accounts"
+          className="hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+        >
+          Accounts
+        </Link>
+        <span>/</span>
+        <span className="text-gray-900 dark:text-gray-100">
+          Edit {account.name}
+        </span>
+      </nav>
+
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+        Edit Account
+      </h1>
+
+      <AccountForm
+        initialData={{
+          id: account.id,
+          name: account.name,
+          type: account.type,
+          currency: account.currency,
+          balance: account.balance,
+          icon: account.icon,
+          color: account.color,
+        }}
+      />
+    </main>
+  );
+}

--- a/src/app/accounts/[id]/not-found.tsx
+++ b/src/app/accounts/[id]/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+export default function AccountNotFound() {
+  return (
+    <main className="flex-1 w-full max-w-xl mx-auto px-4 py-16 text-center">
+      <svg
+        className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600 mb-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+        />
+      </svg>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+        Account not found
+      </h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        This account doesn&apos;t exist or you don&apos;t have access to it.
+      </p>
+      <Link
+        href="/accounts"
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors"
+      >
+        Back to Accounts
+      </Link>
+    </main>
+  );
+}

--- a/src/components/account-card.tsx
+++ b/src/components/account-card.tsx
@@ -2,6 +2,7 @@
 
 import { formatMoney, accountTypeLabel } from "@/lib/format";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useState } from "react";
 
 interface Account {
@@ -106,17 +107,29 @@ export function AccountCard({ account }: { account: Account }) {
         </p>
       </div>
 
-      {/* Delete button */}
-      <button
-        onClick={handleDelete}
-        disabled={isDeleting}
-        className="opacity-0 group-hover:opacity-100 absolute top-2 right-2 p-1 rounded-md text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all disabled:opacity-50"
-        title="Delete account"
-      >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-        </svg>
-      </button>
+      {/* Action buttons */}
+      <div className="opacity-0 group-hover:opacity-100 absolute top-2 right-2 flex items-center gap-1 transition-all">
+        <Link
+          href={`/accounts/${account.id}/edit`}
+          onClick={(e) => e.stopPropagation()}
+          className="p-1 rounded-md text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
+          title="Edit account"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+          </svg>
+        </Link>
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="p-1 rounded-md text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+          title="Delete account"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `/accounts/[id]/edit` page that fetches account data and renders the existing `AccountForm` component in edit mode
- Adds edit button (pencil icon) to `AccountCard`, alongside the existing delete button
- Adds `/accounts/[id]/not-found.tsx` for graceful handling of invalid account IDs

Closes #20

## Test plan
- [ ] Navigate to `/accounts`, create an account, verify edit icon appears on hover
- [ ] Click edit icon, verify form is pre-filled with existing account data
- [ ] Modify fields and submit, verify account is updated
- [ ] Navigate to `/accounts/invalid-id/edit`, verify not-found page is shown
- [ ] Verify Cancel button navigates back

🤖 Generated with [Claude Code](https://claude.com/claude-code)