### PR TITLE
Add WebAuthn login and nav auth integration

### DIFF
--- a/src/app/api/auth/login/options/route.ts
+++ b/src/app/api/auth/login/options/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generateAuthenticationOptions } from "@simplewebauthn/server";
+import { db } from "@/lib/db";
+import { getWebAuthnConfig } from "@/lib/webauthn";
+
+/**
+ * POST /api/auth/login/options
+ * Generate WebAuthn authentication options (challenge) for an existing user.
+ * Body: { email: string }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json();
+
+    if (!email) {
+      return NextResponse.json(
+        { error: "Email is required" },
+        { status: 400 }
+      );
+    }
+
+    // Find user and their credentials
+    const user = await db.user.findUnique({
+      where: { email },
+      include: { credentials: true },
+    });
+
+    if (!user || user.credentials.length === 0) {
+      return NextResponse.json(
+        { error: "No account found with this email. Please register first." },
+        { status: 404 }
+      );
+    }
+
+    const { rpID } = getWebAuthnConfig();
+
+    const options = await generateAuthenticationOptions({
+      rpID,
+      allowCredentials: user.credentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports
+          ? JSON.parse(cred.transports)
+          : undefined,
+      })),
+      userVerification: "preferred",
+    });
+
+    // Store challenge and user ID in cookies
+    const response = NextResponse.json(options);
+    response.cookies.set("ck_auth_challenge", options.challenge, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 300, // 5 minutes
+    });
+    response.cookies.set("ck_auth_user", user.id, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 300,
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Login options error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate login options" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/login/verify/route.ts
+++ b/src/app/api/auth/login/verify/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAuthenticationResponse } from "@simplewebauthn/server";
+import { db } from "@/lib/db";
+import { createSession } from "@/lib/session";
+import { getWebAuthnConfig } from "@/lib/webauthn";
+
+/**
+ * POST /api/auth/login/verify
+ * Verify WebAuthn authentication response and create a session.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    // Retrieve challenge and user ID from cookies
+    const challenge = req.cookies.get("ck_auth_challenge")?.value;
+    const userId = req.cookies.get("ck_auth_user")?.value;
+
+    if (!challenge || !userId) {
+      return NextResponse.json(
+        { error: "Login session expired. Please try again." },
+        { status: 400 }
+      );
+    }
+
+    // Find the credential that was used
+    const credentialId = body.id;
+    const credential = await db.credential.findFirst({
+      where: {
+        userId,
+        credentialId,
+      },
+    });
+
+    if (!credential) {
+      return NextResponse.json(
+        { error: "Credential not found" },
+        { status: 400 }
+      );
+    }
+
+    const { rpID, origin } = getWebAuthnConfig();
+
+    const verification = await verifyAuthenticationResponse({
+      response: body,
+      expectedChallenge: challenge,
+      expectedOrigin: origin,
+      expectedRPID: rpID,
+      credential: {
+        id: credential.credentialId,
+        publicKey: credential.publicKey,
+        counter: Number(credential.counter),
+        transports: credential.transports
+          ? JSON.parse(credential.transports)
+          : undefined,
+      },
+    });
+
+    if (!verification.verified) {
+      return NextResponse.json(
+        { error: "Authentication verification failed" },
+        { status: 400 }
+      );
+    }
+
+    // Update credential counter to prevent replay attacks
+    await db.credential.update({
+      where: { id: credential.id },
+      data: { counter: BigInt(verification.authenticationInfo.newCounter) },
+    });
+
+    // Create session
+    await createSession(userId);
+
+    // Clear auth cookies
+    const response = NextResponse.json({ success: true });
+    response.cookies.delete("ck_auth_challenge");
+    response.cookies.delete("ck_auth_user");
+
+    return response;
+  } catch (error) {
+    console.error("Login verify error:", error);
+    return NextResponse.json(
+      { error: "Login failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { destroySession } from "@/lib/session";
+
+/**
+ * POST /api/auth/logout
+ * Destroy the current session and clear the session cookie.
+ */
+export async function POST() {
+  try {
+    await destroySession();
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Logout error:", error);
+    return NextResponse.json(
+      { error: "Failed to log out" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,36 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { startAuthentication } from "@simplewebauthn/browser";
 import Link from "next/link";
 
 export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      // Step 1: Get authentication options from server
+      const optionsRes = await fetch("/api/auth/login/options", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!optionsRes.ok) {
+        const data = await optionsRes.json();
+        throw new Error(data.error || "Failed to start login");
+      }
+
+      const options = await optionsRes.json();
+
+      // Step 2: Start WebAuthn authentication (browser prompt)
+      const credential = await startAuthentication({ optionsJSON: options });
+
+      // Step 3: Verify with server
+      const verifyRes = await fetch("/api/auth/login/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(credential),
+      });
+
+      if (!verifyRes.ok) {
+        const data = await verifyRes.json();
+        throw new Error(data.error || "Login failed");
+      }
+
+      // Success — redirect to dashboard
+      window.location.href = "/";
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Login failed";
+      // Handle user cancellation
+      if (message.includes("NotAllowedError") || message.includes("cancelled")) {
+        setError("Authentication was cancelled. Please try again.");
+      } else {
+        setError(message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <main className="flex-1 flex items-center justify-center px-4">
-      <div className="w-full max-w-sm text-center">
-        <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-emerald-100 dark:bg-emerald-900/30 mb-4">
-          <svg
-            className="w-8 h-8 text-emerald-600 dark:text-emerald-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-            />
-          </svg>
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-emerald-100 dark:bg-emerald-900/30 mb-4">
+            <svg
+              className="w-8 h-8 text-emerald-600 dark:text-emerald-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Welcome Back
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Sign in with your passkey
+          </p>
         </div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-          Sign In
-        </h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
-          Passkey login will be available in a future update.
+
+        <form onSubmit={handleLogin} className="space-y-4">
+          {error && (
+            <div className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 text-sm text-red-700 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="block w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex items-center justify-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-400 px-4 py-2.5 text-sm font-medium text-white transition-colors"
+          >
+            {loading ? (
+              <>
+                <svg
+                  className="animate-spin h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Signing in...
+              </>
+            ) : (
+              <>
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M7.864 4.243A7.5 7.5 0 0 1 19.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 0 0 4.5 10.5a48.667 48.667 0 0 0-6 3.473m11.45 2.027a48.422 48.422 0 0 1-12.9 0m12.9 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                  />
+                </svg>
+                Sign in with Passkey
+              </>
+            )}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
+          Don&apos;t have an account?{" "}
+          <Link
+            href="/auth/register"
+            className="text-emerald-600 dark:text-emerald-400 hover:underline font-medium"
+          >
+            Create one
+          </Link>
         </p>
-        <Link
-          href="/auth/register"
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition-colors"
-        >
-          Create Account
-        </Link>
       </div>
     </main>
   );

--- a/src/components/logout-button.tsx
+++ b/src/components/logout-button.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function LogoutButton() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogout() {
+    setLoading(true);
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+      router.push("/auth/login");
+      router.refresh();
+    } catch {
+      // Even if the request fails, redirect to login
+      router.push("/auth/login");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleLogout}
+      disabled={loading}
+      className="px-3 py-1.5 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+      title="Sign out"
+    >
+      {loading ? (
+        <svg
+          className="animate-spin h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getSession } from "@/lib/session";
+import { LogoutButton } from "./logout-button";
 
 export async function Nav() {
   const session = await getSession();
@@ -75,9 +76,12 @@ export async function Nav() {
           >
             Categories
           </Link>
-          <span className="ml-2 text-xs text-gray-400 dark:text-gray-500 hidden sm:inline">
-            {session.user.name}
-          </span>
+          <div className="ml-2 flex items-center gap-1 border-l border-gray-200 dark:border-gray-700 pl-2">
+            <span className="text-xs text-gray-500 dark:text-gray-400 hidden sm:inline">
+              {session.user.name}
+            </span>
+            <LogoutButton />
+          </div>
         </nav>
       </div>
     </header>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,7 +19,7 @@ export async function requireUser() {
   const user = await getCurrentUser();
   if (!user) {
     // In server components, redirect to login
-    redirect("/auth/register");
+    redirect("/auth/login");
   }
   return user;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Middleware to protect routes.
- * Redirects unauthenticated users to /auth/register.
+ * Redirects unauthenticated users to /auth/login.
  * Auth pages and API routes for auth are excluded.
  */
 export function middleware(req: NextRequest) {
@@ -25,7 +25,7 @@ export function middleware(req: NextRequest) {
   // Check for session cookie
   const sessionToken = req.cookies.get("ck_session")?.value;
   if (!sessionToken) {
-    const loginUrl = new URL("/auth/register", req.url);
+    const loginUrl = new URL("/auth/login", req.url);
     return NextResponse.redirect(loginUrl);
   }
 


### PR DESCRIPTION
## Summary
- Implements WebAuthn passkey login flow with challenge/verify API endpoints (`/api/auth/login/options`, `/api/auth/login/verify`)
- Adds logout endpoint (`/api/auth/logout`) that destroys sessions and clears cookies
- Updates login page with email input and passkey authentication prompt
- Adds user name display and logout button to nav bar
- Changes unauthenticated redirect from `/auth/register` to `/auth/login`

Closes #51

## Test plan
- [ ] Register a new account, verify redirect to dashboard
- [ ] Log out via nav button, verify redirect to login page
- [ ] Log in with registered passkey, verify redirect to dashboard
- [ ] Visit protected page while unauthenticated, verify redirect to /auth/login
- [ ] Try login with non-existent email, verify error message
- [ ] Cancel passkey prompt, verify friendly error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)