### PR TITLE
Add AI insights dashboard page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,16 @@ ENV PORT=8080
 ENV HOSTNAME=0.0.0.0
 
 RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN adduser --system --uid 1001 --home /home/nextjs nextjs
 
 # Copy standalone output
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
-# Copy Prisma schema and migrations for runtime
+# Copy Prisma schema, migrations, and full node_modules for prisma migrate
 COPY --from=builder /app/prisma ./prisma
-COPY --from=deps /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=deps /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=deps /app/node_modules ./node_modules
 
 # Create data directory for SQLite
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
@@ -47,4 +46,4 @@ USER nextjs
 EXPOSE 8080
 
 # Run migrations and start
-CMD ["sh", "-c", "npx prisma migrate deploy && node server.js"]
+CMD ["sh", "-c", "node node_modules/prisma/build/index.js migrate deploy && node server.js"]

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,25 @@
+import { requireUser } from "@/lib/auth";
+import { InsightsDashboard } from "@/components/insights-dashboard";
+
+export const metadata = {
+  title: "AI Insights — CoinKeeper",
+};
+
+export default async function InsightsPage() {
+  await requireUser();
+
+  return (
+    <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          AI Insights
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          AI-powered analysis of your spending patterns and financial health
+        </p>
+      </div>
+
+      <InsightsDashboard />
+    </main>
+  );
+}

--- a/src/components/insights-dashboard.tsx
+++ b/src/components/insights-dashboard.tsx
@@ -1,0 +1,313 @@
+"use client";
+import type { JSX } from "react";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Insight {
+  type: "spending_pattern" | "budget_recommendation" | "savings_opportunity" | "monthly_summary" | "alert";
+  title: string;
+  description: string;
+  priority: "high" | "medium" | "low";
+  category?: string;
+  amount?: number;
+  currency?: string;
+}
+
+interface InsightResponse {
+  insights: Insight[];
+  generatedAt: string;
+  period: string;
+  summary: string;
+}
+
+const PERIODS = [
+  { value: "30d", label: "30 days" },
+  { value: "90d", label: "90 days" },
+  { value: "1y", label: "1 year" },
+] as const;
+
+const TYPE_CONFIG: Record<Insight["type"], { label: string; icon: JSX.Element; color: string }> = {
+  spending_pattern: {
+    label: "Spending Pattern",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+      </svg>
+    ),
+    color: "text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20",
+  },
+  budget_recommendation: {
+    label: "Budget Tip",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+      </svg>
+    ),
+    color: "text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-900/20",
+  },
+  savings_opportunity: {
+    label: "Savings Opportunity",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
+      </svg>
+    ),
+    color: "text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20",
+  },
+  monthly_summary: {
+    label: "Monthly Summary",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+      </svg>
+    ),
+    color: "text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50",
+  },
+  alert: {
+    label: "Alert",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+      </svg>
+    ),
+    color: "text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20",
+  },
+};
+
+const PRIORITY_STYLES: Record<Insight["priority"], string> = {
+  high: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  medium: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  low: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+};
+
+function InsightCard({ insight }: { insight: Insight }) {
+  const config = TYPE_CONFIG[insight.type];
+
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 hover:border-gray-300 dark:hover:border-gray-700 transition-colors">
+      <div className="flex items-start gap-3">
+        <div className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${config.color}`}>
+          {config.icon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {insight.title}
+            </h3>
+            <span className={`flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-medium ${PRIORITY_STYLES[insight.priority]}`}>
+              {insight.priority}
+            </span>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+            {insight.description}
+          </p>
+          <div className="flex items-center gap-3 mt-2">
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              {config.label}
+            </span>
+            {insight.category && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                &middot; {insight.category}
+              </span>
+            )}
+            {insight.amount != null && insight.currency && (
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                &middot; {insight.currency} {insight.amount.toFixed(2)}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Summary skeleton */}
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 animate-pulse">
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2" />
+        <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+      </div>
+      {/* Card skeletons */}
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 animate-pulse">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-lg flex-shrink-0" />
+            <div className="flex-1">
+              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3 mb-2" />
+              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-full mb-1" />
+              <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-2/3" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function InsightsDashboard() {
+  const [data, setData] = useState<InsightResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [period, setPeriod] = useState<string>("30d");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchInsights = useCallback(async (selectedPeriod: string, refresh = false) => {
+    if (refresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({ period: selectedPeriod });
+      if (refresh) params.set("refresh", "true");
+
+      const res = await fetch(`/api/insights?${params}`);
+      if (!res.ok) {
+        throw new Error(`Failed to load insights (${res.status})`);
+      }
+      const json: InsightResponse = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchInsights(period);
+  }, [period, fetchInsights]);
+
+  const handlePeriodChange = (newPeriod: string) => {
+    if (newPeriod !== period) {
+      setPeriod(newPeriod);
+    }
+  };
+
+  const handleRefresh = () => {
+    fetchInsights(period, true);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Controls: Period tabs + Refresh */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+          {PERIODS.map((p) => (
+            <button
+              key={p.value}
+              onClick={() => handlePeriodChange(p.value)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                period === p.value
+                  ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing || loading}
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+        >
+          <svg
+            className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182M2.985 14.652"
+            />
+          </svg>
+          {refreshing ? "Generating..." : "Refresh"}
+        </button>
+      </div>
+
+      {/* Loading state */}
+      {loading && <LoadingSkeleton />}
+
+      {/* Error state */}
+      {!loading && error && (
+        <div className="text-center py-12 border-2 border-dashed border-red-200 dark:border-red-800/50 rounded-xl">
+          <svg className="w-12 h-12 mx-auto text-red-300 dark:text-red-600 mb-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+          </svg>
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+            Failed to load insights
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{error}</p>
+          <button
+            onClick={() => fetchInsights(period)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Data loaded */}
+      {!loading && !error && data && (
+        <>
+          {/* Summary banner */}
+          <div className="bg-gradient-to-r from-emerald-50 to-blue-50 dark:from-emerald-900/20 dark:to-blue-900/20 border border-emerald-200/50 dark:border-emerald-800/30 rounded-xl p-5">
+            <div className="flex items-start gap-3">
+              <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+                </svg>
+              </div>
+              <div>
+                <h2 className="text-sm font-semibold text-emerald-800 dark:text-emerald-300 mb-0.5">
+                  AI Financial Summary
+                </h2>
+                <p className="text-sm text-emerald-700 dark:text-emerald-400/80 leading-relaxed">
+                  {data.summary}
+                </p>
+                <p className="text-xs text-emerald-600/60 dark:text-emerald-500/50 mt-2">
+                  Generated {new Date(data.generatedAt).toLocaleString()}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Empty state */}
+          {data.insights.length === 0 && (
+            <div className="text-center py-16 border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-xl">
+              <svg className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+              </svg>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+                No insights available
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Add more transactions to unlock AI-powered financial insights.
+              </p>
+            </div>
+          )}
+
+          {/* Insight cards */}
+          {data.insights.length > 0 && (
+            <div className="space-y-3">
+              {data.insights.map((insight, idx) => (
+                <InsightCard key={idx} insight={insight} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -102,6 +102,12 @@ export async function Nav() {
             Analytics
           </Link>
           <Link
+            href="/insights"
+            className="px-3 py-1.5 rounded-lg text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            Insights
+          </Link>
+          <Link
             href="/categories"
             className="px-3 py-1.5 rounded-lg text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >


### PR DESCRIPTION
## Summary
- Adds `/insights` page with AI-powered financial insight cards grouped by type (spending patterns, budget tips, savings opportunities, monthly summaries, alerts)
- Period selector (30 days, 90 days, 1 year) with loading skeleton, error/empty states, and refresh button
- Adds Insights link to navigation bar
- Fixes Dockerfile for Prisma runtime compatibility (copies full node_modules for `prisma migrate deploy`)

Closes #83

## Test plan
- [ ] Navigate to /insights page — verify loading skeleton appears
- [ ] Verify insight cards render with correct type icons and priority badges
- [ ] Switch between period tabs — verify data refreshes
- [ ] Click refresh button — verify spinner and new data
- [ ] Verify empty state shows when no transaction data exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)