### PR TITLE
Add low balance warnings for account monitoring

### DIFF
--- a/prisma/migrations/20260326184424_add_low_balance_threshold/migration.sql
+++ b/prisma/migrations/20260326184424_add_low_balance_threshold/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN "lowBalanceThreshold" REAL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,7 +73,8 @@ model Account {
   balance   Float    @default(0)
   icon      String?
   color     String?
-  isArchived Boolean @default(false)
+  isArchived        Boolean @default(false)
+  lowBalanceThreshold Float?  // nullable — when set, triggers low_balance notification
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/accounts/[id]/edit/page.tsx
+++ b/src/app/accounts/[id]/edit/page.tsx
@@ -53,6 +53,7 @@ export default async function EditAccountPage({
           balance: account.balance,
           icon: account.icon,
           color: account.color,
+          lowBalanceThreshold: account.lowBalanceThreshold,
         }}
       />
     </main>

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -38,7 +38,7 @@ export async function PATCH(
   }
 
   const body = await request.json();
-  const { name, type, currency, balance, icon, color, isArchived } = body;
+  const { name, type, currency, balance, icon, color, isArchived, lowBalanceThreshold } = body;
 
   const validTypes = ["cash", "bank", "wallet", "credit"];
   if (type !== undefined && !validTypes.includes(type)) {
@@ -58,6 +58,10 @@ export async function PATCH(
       ...(icon !== undefined && { icon }),
       ...(color !== undefined && { color }),
       ...(isArchived !== undefined && { isArchived }),
+      ...(lowBalanceThreshold !== undefined && {
+        lowBalanceThreshold:
+          lowBalanceThreshold === null ? null : parseFloat(lowBalanceThreshold),
+      }),
     },
   });
 

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { name, type, currency, balance, icon, color } = body;
+  const { name, type, currency, balance, icon, color, lowBalanceThreshold } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {
     return NextResponse.json(
@@ -77,6 +77,10 @@ export async function POST(request: NextRequest) {
       balance: typeof balance === "number" ? balance : 0,
       icon: icon || null,
       color: color || null,
+      lowBalanceThreshold:
+        lowBalanceThreshold !== undefined && lowBalanceThreshold !== null
+          ? parseFloat(lowBalanceThreshold)
+          : null,
     },
   });
 

--- a/src/app/api/notifications/check-balance/route.ts
+++ b/src/app/api/notifications/check-balance/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { checkAllLowBalances } from "@/lib/check-low-balance";
+
+/**
+ * POST /api/notifications/check-balance — trigger low balance check for all user accounts
+ * Returns the number of new notifications created.
+ */
+export async function POST() {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const created = await checkAllLowBalances(user.id);
+
+  return NextResponse.json({ checked: true, notificationsCreated: created });
+}

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
 import { getSpaceContext, checkSpacePermission, getSpaceAccountIds } from "@/lib/space-context";
+import { checkLowBalance } from "@/lib/check-low-balance";
 
 // GET /api/transactions — list transactions with optional filters
 export async function GET(request: NextRequest) {
@@ -329,6 +330,17 @@ export async function POST(request: NextRequest) {
 
     return txn;
   });
+
+  // Check low balance warnings (fire and forget — don't block response)
+  const accountsToCheck: string[] = [];
+  if (type === "expense" && fromAccountId) accountsToCheck.push(fromAccountId);
+  if (type === "transfer") {
+    if (fromAccountId) accountsToCheck.push(fromAccountId);
+  }
+  // Run checks asynchronously
+  for (const accId of accountsToCheck) {
+    checkLowBalance(accId).catch(() => {});
+  }
 
   return NextResponse.json(transaction, { status: 201 });
 }

--- a/src/components/account-form.tsx
+++ b/src/components/account-form.tsx
@@ -25,6 +25,7 @@ interface AccountFormProps {
     balance: number;
     icon: string | null;
     color: string | null;
+    lowBalanceThreshold: number | null;
   };
 }
 
@@ -39,6 +40,9 @@ export function AccountForm({ initialData }: AccountFormProps) {
     initialData?.balance?.toString() ?? "0"
   );
   const [color, setColor] = useState(initialData?.color ?? "#10b981");
+  const [lowBalanceThreshold, setLowBalanceThreshold] = useState(
+    initialData?.lowBalanceThreshold?.toString() ?? ""
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -67,6 +71,9 @@ export function AccountForm({ initialData }: AccountFormProps) {
           currency,
           balance: parseFloat(balance) || 0,
           color,
+          lowBalanceThreshold: lowBalanceThreshold.trim()
+            ? parseFloat(lowBalanceThreshold)
+            : null,
         }),
       });
 
@@ -197,6 +204,31 @@ export function AccountForm({ initialData }: AccountFormProps) {
             {color}
           </span>
         </div>
+      </div>
+
+      {/* Low Balance Alert */}
+      <div>
+        <label
+          htmlFor="lowBalanceThreshold"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
+        >
+          Low Balance Alert
+        </label>
+        <div className="flex items-center gap-3">
+          <input
+            id="lowBalanceThreshold"
+            type="number"
+            step="0.01"
+            min="0"
+            value={lowBalanceThreshold}
+            onChange={(e) => setLowBalanceThreshold(e.target.value)}
+            placeholder="No alert"
+            className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent tabular-nums"
+          />
+        </div>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Get notified when balance drops below this amount. Leave empty to disable.
+        </p>
       </div>
 
       {/* Actions */}

--- a/src/lib/check-low-balance.ts
+++ b/src/lib/check-low-balance.ts
@@ -1,0 +1,89 @@
+/**
+ * Low balance warning detection.
+ * Checks if an account balance is below its configured threshold
+ * and creates a notification if one hasn't been sent recently (within 24h).
+ */
+
+import { db } from "@/lib/db";
+
+const COOLDOWN_HOURS = 24;
+
+/**
+ * Check a single account for low balance and create notification if needed.
+ * Returns true if a notification was created.
+ */
+export async function checkLowBalance(accountId: string): Promise<boolean> {
+  const account = await db.account.findUnique({
+    where: { id: accountId },
+  });
+
+  if (!account || account.lowBalanceThreshold === null) {
+    return false;
+  }
+
+  // Only trigger if balance is at or below the threshold
+  if (account.balance > account.lowBalanceThreshold) {
+    return false;
+  }
+
+  // Check for recent notification to avoid spam
+  const cooldownDate = new Date(
+    Date.now() - COOLDOWN_HOURS * 60 * 60 * 1000
+  );
+
+  const recentNotification = await db.notification.findFirst({
+    where: {
+      userId: account.userId,
+      type: "low_balance",
+      createdAt: { gte: cooldownDate },
+      metadata: { contains: account.id },
+    },
+  });
+
+  if (recentNotification) {
+    return false;
+  }
+
+  // Create low balance notification
+  await db.notification.create({
+    data: {
+      userId: account.userId,
+      spaceId: account.spaceId,
+      type: "low_balance",
+      title: `Low balance: ${account.name}`,
+      message: `Your ${account.name} account balance is ${account.currency} ${account.balance.toFixed(2)}, which is below your alert threshold of ${account.currency} ${account.lowBalanceThreshold.toFixed(2)}.`,
+      priority: "high",
+      metadata: JSON.stringify({
+        accountId: account.id,
+        accountName: account.name,
+        balance: account.balance,
+        threshold: account.lowBalanceThreshold,
+        currency: account.currency,
+      }),
+    },
+  });
+
+  return true;
+}
+
+/**
+ * Check all accounts for a user for low balance warnings.
+ * Returns number of notifications created.
+ */
+export async function checkAllLowBalances(userId: string): Promise<number> {
+  const accounts = await db.account.findMany({
+    where: {
+      userId,
+      isArchived: false,
+      lowBalanceThreshold: { not: null },
+    },
+  });
+
+  let created = 0;
+  for (const account of accounts) {
+    const notified = await checkLowBalance(account.id);
+    if (notified) created++;
+  }
+
+  return created;
+}

--- a/src/lib/execute-scheduled-transfer.ts
+++ b/src/lib/execute-scheduled-transfer.ts
@@ -6,6 +6,7 @@
 import { db } from "@/lib/db";
 import { fetchExchangeRate } from "@/lib/exchange-rate";
 import { calculateNextExecution } from "@/lib/schedule";
+import { checkLowBalance } from "@/lib/check-low-balance";
 
 export interface ExecutionResult {
   scheduleId: string;
@@ -143,6 +144,9 @@ export async function executeScheduledTransfer(
 
     return txn;
   });
+
+  // Check low balance on source account (fire and forget)
+  checkLowBalance(schedule.fromAccountId).catch(() => {});
 
   return {
     scheduleId: schedule.id,


### PR DESCRIPTION
## Summary
- Add `lowBalanceThreshold` field to Account model — users set an optional balance floor per account
- New `checkLowBalance()` utility creates `low_balance` notifications when balance drops below threshold, with 24h cooldown to prevent duplicates
- Integrated into transaction creation (expenses, transfers) and scheduled transfer execution — checks fire asynchronously after balance changes
- Account create/edit form updated with "Low Balance Alert" field
- New `POST /api/notifications/check-balance` endpoint for manual/cron-triggered checks across all user accounts

Closes #88
Part of #13

## Test plan
- [ ] Create an account with a low balance threshold of 100
- [ ] Add an expense that drops the balance below 100
- [ ] Verify a low_balance notification appears in the notification center
- [ ] Add another expense — verify no duplicate notification within 24h
- [ ] Edit an account to remove the threshold, verify no more alerts
- [ ] Test scheduled transfer that drops source account below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)