### PR TITLE
Add scheduled transfer confirmation notifications

### DIFF
--- a/src/lib/execute-scheduled-transfer.ts
+++ b/src/lib/execute-scheduled-transfer.ts
@@ -148,6 +148,46 @@ export async function executeScheduledTransfer(
   // Check low balance on source account (fire and forget)
   checkLowBalance(schedule.fromAccountId).catch(() => {});
 
+  // Create transfer confirmation notification
+  const fromName = schedule.fromAccount.name;
+  const toName = schedule.toAccount.name;
+  const fromCurrency = schedule.fromAccount.currency;
+  const toCurrency = schedule.toAccount.currency;
+  const isCrossCurrency = fromCurrency !== toCurrency;
+
+  let message = `Transferred ${fromCurrency} ${schedule.amount.toFixed(2)} from ${fromName} to ${toName}.`;
+  if (isCrossCurrency) {
+    message += ` Received ${toCurrency} ${toAmount.toFixed(2)} (rate: ${exchangeRate.toFixed(4)}).`;
+  }
+  if (deactivated) {
+    message += " This was the final scheduled execution — the schedule is now complete.";
+  } else {
+    message += ` Next execution: ${nextExecution.toLocaleDateString()}.`;
+  }
+
+  db.notification
+    .create({
+      data: {
+        userId,
+        spaceId: schedule.fromAccount.spaceId,
+        type: "transfer_confirmation",
+        title: `Scheduled transfer executed: ${fromName} → ${toName}`,
+        message,
+        priority: "medium",
+        metadata: JSON.stringify({
+          scheduleId: schedule.id,
+          transactionId: result.id,
+          fromAccountId: schedule.fromAccountId,
+          toAccountId: schedule.toAccountId,
+          amount: schedule.amount,
+          toAmount,
+          exchangeRate,
+          deactivated,
+        }),
+      },
+    })
+    .catch(() => {});
+
   return {
     scheduleId: schedule.id,
     transactionId: result.id,


### PR DESCRIPTION
## Summary
- After a scheduled transfer executes, create a `transfer_confirmation` notification with transfer details
- Includes from/to account names, amounts, exchange rate for cross-currency transfers
- Notes when a schedule completes its final execution (deactivated)
- Shows next execution date for ongoing schedules
- Fire-and-forget pattern — doesn't block execution flow

Closes #90
Part of #13

## Test plan
- [ ] Execute a scheduled transfer and verify a transfer_confirmation notification appears
- [ ] Execute a cross-currency transfer and verify exchange rate is included in the message
- [ ] Execute a transfer that hits the end date and verify "final execution" is mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)