### PR TITLE
Add expense logging reminders with configurable period

### DIFF
--- a/prisma/migrations/20260326184852_add_reminder_days/migration.sql
+++ b/prisma/migrations/20260326184852_add_reminder_days/migration.sql
@@ -1,0 +1,1 @@
+-- This is an empty migration.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,11 +10,12 @@ datasource db {
 // ─── Users ───────────────────────────────────────────────────────────
 
 model User {
-  id        String   @id @default(cuid())
-  name      String
-  email     String   @unique
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id           String   @id @default(cuid())
+  name         String
+  email        String   @unique
+  reminderDays Int?     // days without transactions before reminder (null = disabled)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   accounts           Account[]
   transactions       Transaction[]

--- a/src/app/api/notifications/check-reminders/route.ts
+++ b/src/app/api/notifications/check-reminders/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { checkExpenseReminder } from "@/lib/check-expense-reminders";
+
+/**
+ * POST /api/notifications/check-reminders — trigger expense reminder check
+ */
+export async function POST() {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const created = await checkExpenseReminder(user.id);
+
+  return NextResponse.json({ checked: true, notificationCreated: created });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+/**
+ * GET /api/settings — get current user settings
+ */
+export async function GET() {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const fullUser = await db.user.findUnique({
+    where: { id: user.id },
+    select: { reminderDays: true },
+  });
+
+  return NextResponse.json({ reminderDays: fullUser?.reminderDays ?? null });
+}
+
+/**
+ * PATCH /api/settings — update user settings
+ */
+export async function PATCH(req: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { reminderDays } = body;
+
+  // Validate reminderDays
+  if (reminderDays !== null && reminderDays !== undefined) {
+    const days = parseInt(reminderDays, 10);
+    if (isNaN(days) || days < 1) {
+      return NextResponse.json(
+        { error: "Reminder days must be a positive integer or null" },
+        { status: 400 }
+      );
+    }
+  }
+
+  await db.user.update({
+    where: { id: user.id },
+    data: {
+      reminderDays: reminderDays !== null && reminderDays !== undefined
+        ? parseInt(reminderDays, 10)
+        : null,
+    },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,12 +1,18 @@
 import { requireUser } from "@/lib/auth";
 import { TelegramLinkCard } from "@/components/telegram-link-card";
 import { getTelegramLinkStatus } from "@/lib/telegram";
+import { NotificationSettings } from "@/components/notification-settings";
+import { db } from "@/lib/db";
 
 export default async function SettingsPage() {
   const user = await requireUser();
 
   const telegramLink = await getTelegramLinkStatus(user.id);
   const botConfigured = !!process.env.TELEGRAM_BOT_TOKEN;
+  const fullUser = await db.user.findUnique({
+    where: { id: user.id },
+    select: { reminderDays: true },
+  });
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
@@ -31,6 +37,11 @@ export default async function SettingsPage() {
             </div>
           </dl>
         </div>
+
+        {/* Notifications section */}
+        <NotificationSettings
+          initialReminderDays={fullUser?.reminderDays ?? null}
+        />
 
         {/* Telegram section */}
         <TelegramLinkCard

--- a/src/components/notification-settings.tsx
+++ b/src/components/notification-settings.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+
+interface NotificationSettingsProps {
+  initialReminderDays: number | null;
+}
+
+export function NotificationSettings({
+  initialReminderDays,
+}: NotificationSettingsProps) {
+  const [reminderDays, setReminderDays] = useState(
+    initialReminderDays?.toString() ?? ""
+  );
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setError(null);
+    setSaved(false);
+    setSaving(true);
+
+    try {
+      const value = reminderDays.trim() ? parseInt(reminderDays, 10) : null;
+      if (value !== null && (isNaN(value) || value < 1)) {
+        setError("Please enter a positive number of days or leave empty to disable.");
+        return;
+      }
+
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reminderDays: value }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to save");
+        return;
+      }
+
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        Notifications
+      </h2>
+
+      <div className="space-y-4">
+        <div>
+          <label
+            htmlFor="reminderDays"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5"
+          >
+            Expense logging reminder
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              id="reminderDays"
+              type="number"
+              min="1"
+              step="1"
+              value={reminderDays}
+              onChange={(e) => setReminderDays(e.target.value)}
+              placeholder="Disabled"
+              className="w-32 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent tabular-nums"
+            />
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              days without logging
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Get reminded when you haven&apos;t logged any transactions for this many days.
+            Leave empty to disable.
+          </p>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? "Saving..." : saved ? "Saved!" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/check-expense-reminders.ts
+++ b/src/lib/check-expense-reminders.ts
@@ -1,0 +1,85 @@
+/**
+ * Expense logging reminder detection.
+ * Creates a notification when user hasn't logged any transactions
+ * for their configured reminder period.
+ */
+
+import { db } from "@/lib/db";
+
+const COOLDOWN_HOURS = 24;
+
+/**
+ * Check if a user needs an expense logging reminder.
+ * Returns true if a notification was created.
+ */
+export async function checkExpenseReminder(userId: string): Promise<boolean> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, reminderDays: true },
+  });
+
+  if (!user || user.reminderDays === null) {
+    return false;
+  }
+
+  // Find the most recent transaction
+  const lastTransaction = await db.transaction.findFirst({
+    where: { userId },
+    orderBy: { date: "desc" },
+    select: { date: true },
+  });
+
+  const now = new Date();
+  const thresholdDate = new Date(
+    now.getTime() - user.reminderDays * 24 * 60 * 60 * 1000
+  );
+
+  // If there's a recent transaction within the reminder period, no reminder needed
+  if (lastTransaction && lastTransaction.date > thresholdDate) {
+    return false;
+  }
+
+  // Check for recent reminder notification to avoid spam
+  const cooldownDate = new Date(
+    now.getTime() - COOLDOWN_HOURS * 60 * 60 * 1000
+  );
+
+  const recentReminder = await db.notification.findFirst({
+    where: {
+      userId,
+      type: "expense_reminder",
+      createdAt: { gte: cooldownDate },
+    },
+  });
+
+  if (recentReminder) {
+    return false;
+  }
+
+  // Calculate how many days since last transaction
+  const daysSinceLastTransaction = lastTransaction
+    ? Math.floor(
+        (now.getTime() - lastTransaction.date.getTime()) / (24 * 60 * 60 * 1000)
+      )
+    : null;
+
+  const message = daysSinceLastTransaction !== null
+    ? `You haven't logged any transactions in ${daysSinceLastTransaction} days. Don't forget to track your expenses!`
+    : `You haven't logged any transactions yet. Start tracking your expenses to get insights!`;
+
+  await db.notification.create({
+    data: {
+      userId,
+      type: "expense_reminder",
+      title: "Time to log your expenses",
+      message,
+      priority: "low",
+      metadata: JSON.stringify({
+        daysSinceLastTransaction,
+        reminderDays: user.reminderDays,
+      }),
+    },
+  });
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Add `reminderDays` field to User model — configurable period (days) without transactions before a reminder fires
- New notification settings section on settings page with save button
- New `POST /api/settings` endpoint for user settings (GET + PATCH)
- New `checkExpenseReminder()` utility with 24h cooldown to prevent spam
- New `POST /api/notifications/check-reminders` endpoint for cron/manual trigger

Closes #92
Part of #13

## Test plan
- [ ] Go to settings, set reminder days to 1
- [ ] Trigger check-reminders endpoint — verify expense_reminder notification appears
- [ ] Log a transaction, trigger again — verify no reminder
- [ ] Clear reminder days, save — verify setting is null
- [ ] Trigger check again — verify no reminder when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)