### PR TITLE
Add web push notification delivery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,15 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
@@ -2018,6 +2020,16 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
@@ -2617,6 +2629,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2827,6 +2848,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asn1js": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
@@ -2913,6 +2946,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2970,6 +3009,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -3545,6 +3590,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/effect": {
@@ -4761,6 +4815,28 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4807,6 +4883,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5385,6 +5467,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5780,6 +5883,12 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5797,7 +5906,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6717,6 +6825,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6751,6 +6879,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -7632,6 +7766,25 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",

--- a/prisma/migrations/20260326190847_add_push_subscriptions/migration.sql
+++ b/prisma/migrations/20260326190847_add_push_subscriptions/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   telegramLinkCodes TelegramLinkCode[]
   products         Product[]
   notifications    Notification[]
+  pushSubscriptions PushSubscription[]
 }
 
 // ─── WebAuthn Credentials ────────────────────────────────────────────
@@ -308,6 +309,21 @@ model Notification {
   @@index([userId, read])
   @@index([userId, createdAt])
   @@index([spaceId])
+}
+
+// ─── Push Subscriptions ─────────────────────────────────────────────
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  endpoint  String   @unique
+  p256dh    String   // public key
+  auth      String   // auth secret
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 // ─── Shared Spaces ───────────────────────────────────────────────────

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,70 @@
+/**
+ * CoinKeeper Service Worker
+ * Handles push notifications and notification click events.
+ */
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  try {
+    const payload = event.data.json();
+
+    const options = {
+      body: payload.body || "",
+      icon: payload.icon || "/icon-192.png",
+      badge: payload.badge || "/icon-badge.png",
+      tag: payload.tag || "coinkeeper",
+      data: {
+        url: payload.url || "/notifications",
+        ...payload.data,
+      },
+      vibrate: [200, 100, 200],
+      requireInteraction: payload.data?.priority === "high",
+    };
+
+    event.waitUntil(
+      self.registration.showNotification(payload.title || "CoinKeeper", options)
+    );
+  } catch (err) {
+    console.error("Push event handler error:", err);
+  }
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const url = event.notification.data?.url || "/notifications";
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clientList) => {
+      // If there's already an open window, focus it and navigate
+      for (const client of clientList) {
+        if ("focus" in client) {
+          client.focus();
+          client.navigate(url);
+          return;
+        }
+      }
+      // Otherwise open a new window
+      return self.clients.openWindow(url);
+    })
+  );
+});
+
+self.addEventListener("pushsubscriptionchange", (event) => {
+  // Handle subscription refresh by re-subscribing
+  event.waitUntil(
+    self.registration.pushManager
+      .subscribe(event.oldSubscription?.options || { userVisibleOnly: true })
+      .then((subscription) => {
+        return fetch("/api/push/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(subscription.toJSON()),
+        });
+      })
+      .catch((err) => {
+        console.error("Push subscription change handler error:", err);
+      })
+  );
+});

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+/**
+ * POST /api/push/subscribe — save a push subscription for the authenticated user
+ */
+export async function POST(req: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const { endpoint, keys } = body;
+
+    if (!endpoint || !keys?.p256dh || !keys?.auth) {
+      return NextResponse.json(
+        { error: "Invalid subscription: endpoint, keys.p256dh, and keys.auth are required" },
+        { status: 400 }
+      );
+    }
+
+    // Upsert: if the endpoint already exists, update keys (they may rotate)
+    const subscription = await db.pushSubscription.upsert({
+      where: { endpoint },
+      update: {
+        userId: user.id,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      },
+      create: {
+        userId: user.id,
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      },
+    });
+
+    return NextResponse.json({ id: subscription.id }, { status: 201 });
+  } catch (err) {
+    console.error("Push subscribe error:", err);
+    return NextResponse.json(
+      { error: "Failed to save subscription" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/push/subscribe — remove a push subscription
+ */
+export async function DELETE(req: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const { endpoint } = body;
+
+    if (!endpoint) {
+      return NextResponse.json(
+        { error: "endpoint is required" },
+        { status: 400 }
+      );
+    }
+
+    await db.pushSubscription.deleteMany({
+      where: {
+        userId: user.id,
+        endpoint,
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Push unsubscribe error:", err);
+    return NextResponse.json(
+      { error: "Failed to remove subscription" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/push/vapid-key/route.ts
+++ b/src/app/api/push/vapid-key/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getVapidPublicKey } from "@/lib/push-notifications";
+
+/**
+ * GET /api/push/vapid-key — return the VAPID public key for client-side push registration
+ */
+export async function GET() {
+  const publicKey = getVapidPublicKey();
+
+  if (!publicKey) {
+    return NextResponse.json(
+      { error: "Push notifications not configured" },
+      { status: 503 }
+    );
+  }
+
+  return NextResponse.json({ publicKey });
+}

--- a/src/components/notification-settings.tsx
+++ b/src/components/notification-settings.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
+import {
+  isPushSupported,
+  getPushPermission,
+  isPushSubscribed,
+  subscribeToPush,
+  unsubscribeFromPush,
+} from "@/lib/push-client";
 
 interface NotificationSettingsProps {
   initialReminderDays: number | null;
@@ -15,6 +22,28 @@ export function NotificationSettings({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Push notification state
+  const [pushSupported, setPushSupported] = useState(false);
+  const [pushEnabled, setPushEnabled] = useState(false);
+  const [pushLoading, setPushLoading] = useState(false);
+  const [pushError, setPushError] = useState<string | null>(null);
+  const [pushPermission, setPushPermission] = useState<string>("default");
+
+  const checkPushStatus = useCallback(async () => {
+    const supported = isPushSupported();
+    setPushSupported(supported);
+
+    if (supported) {
+      setPushPermission(getPushPermission());
+      const subscribed = await isPushSubscribed();
+      setPushEnabled(subscribed);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkPushStatus();
+  }, [checkPushStatus]);
 
   const handleSave = async () => {
     setError(null);
@@ -49,13 +78,105 @@ export function NotificationSettings({
     }
   };
 
+  const handlePushToggle = async () => {
+    setPushError(null);
+    setPushLoading(true);
+
+    try {
+      if (pushEnabled) {
+        await unsubscribeFromPush();
+        setPushEnabled(false);
+      } else {
+        const success = await subscribeToPush();
+        if (success) {
+          setPushEnabled(true);
+        } else {
+          setPushError(
+            "Notification permission was denied. Please allow notifications in your browser settings."
+          );
+        }
+      }
+      setPushPermission(getPushPermission());
+    } catch (err) {
+      setPushError(
+        err instanceof Error ? err.message : "Failed to update push notification settings"
+      );
+    } finally {
+      setPushLoading(false);
+    }
+  };
+
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-6">
       <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
         Notifications
       </h2>
 
-      <div className="space-y-4">
+      <div className="space-y-6">
+        {/* Push Notifications Toggle */}
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Push notifications
+            </label>
+            {pushSupported && (
+              <button
+                onClick={handlePushToggle}
+                disabled={pushLoading || pushPermission === "denied"}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+                  pushEnabled
+                    ? "bg-emerald-600"
+                    : "bg-gray-300 dark:bg-gray-600"
+                }`}
+                role="switch"
+                aria-checked={pushEnabled}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    pushEnabled ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            )}
+          </div>
+
+          {!pushSupported && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Push notifications are not supported in this browser.
+            </p>
+          )}
+
+          {pushSupported && pushPermission === "denied" && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Notification permission has been blocked. Please enable notifications in your browser settings to receive push alerts.
+            </p>
+          )}
+
+          {pushSupported && pushPermission !== "denied" && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {pushEnabled
+                ? "You will receive browser push notifications for alerts like low balance, unusual spending, and transfer confirmations."
+                : "Enable to receive browser push notifications when you're not actively using CoinKeeper."}
+            </p>
+          )}
+
+          {pushLoading && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {pushEnabled ? "Disabling..." : "Enabling..."}
+            </p>
+          )}
+
+          {pushError && (
+            <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+              {pushError}
+            </p>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 dark:border-gray-800" />
+
+        {/* Expense Logging Reminder */}
         <div>
           <label
             htmlFor="reminderDays"

--- a/src/lib/check-expense-reminders.ts
+++ b/src/lib/check-expense-reminders.ts
@@ -5,6 +5,7 @@
  */
 
 import { db } from "@/lib/db";
+import { sendPushForNotification } from "@/lib/push-notifications";
 
 const COOLDOWN_HOURS = 24;
 
@@ -67,19 +68,30 @@ export async function checkExpenseReminder(userId: string): Promise<boolean> {
     ? `You haven't logged any transactions in ${daysSinceLastTransaction} days. Don't forget to track your expenses!`
     : `You haven't logged any transactions yet. Start tracking your expenses to get insights!`;
 
+  const title = "Time to log your expenses";
+  const priority = "low";
+
   await db.notification.create({
     data: {
       userId,
       type: "expense_reminder",
-      title: "Time to log your expenses",
+      title,
       message,
-      priority: "low",
+      priority,
       metadata: JSON.stringify({
         daysSinceLastTransaction,
         reminderDays: user.reminderDays,
       }),
     },
   });
+
+  // Send push notification
+  sendPushForNotification(userId, {
+    type: "expense_reminder",
+    title,
+    message,
+    priority,
+  }).catch(() => {}); // fire-and-forget
 
   return true;
 }

--- a/src/lib/check-low-balance.ts
+++ b/src/lib/check-low-balance.ts
@@ -5,6 +5,7 @@
  */
 
 import { db } from "@/lib/db";
+import { sendPushForNotification } from "@/lib/push-notifications";
 
 const COOLDOWN_HOURS = 24;
 
@@ -45,14 +46,18 @@ export async function checkLowBalance(accountId: string): Promise<boolean> {
   }
 
   // Create low balance notification
+  const title = `Low balance: ${account.name}`;
+  const message = `Your ${account.name} account balance is ${account.currency} ${account.balance.toFixed(2)}, which is below your alert threshold of ${account.currency} ${account.lowBalanceThreshold.toFixed(2)}.`;
+  const priority = "high";
+
   await db.notification.create({
     data: {
       userId: account.userId,
       spaceId: account.spaceId,
       type: "low_balance",
-      title: `Low balance: ${account.name}`,
-      message: `Your ${account.name} account balance is ${account.currency} ${account.balance.toFixed(2)}, which is below your alert threshold of ${account.currency} ${account.lowBalanceThreshold.toFixed(2)}.`,
-      priority: "high",
+      title,
+      message,
+      priority,
       metadata: JSON.stringify({
         accountId: account.id,
         accountName: account.name,
@@ -62,6 +67,14 @@ export async function checkLowBalance(accountId: string): Promise<boolean> {
       }),
     },
   });
+
+  // Send push notification
+  sendPushForNotification(account.userId, {
+    type: "low_balance",
+    title,
+    message,
+    priority,
+  }).catch(() => {}); // fire-and-forget
 
   return true;
 }

--- a/src/lib/check-unusual-spending.ts
+++ b/src/lib/check-unusual-spending.ts
@@ -6,6 +6,7 @@
  */
 
 import { db } from "@/lib/db";
+import { sendPushForNotification } from "@/lib/push-notifications";
 
 const COOLDOWN_HOURS = 24;
 const HISTORY_DAYS = 90;
@@ -103,6 +104,7 @@ export async function checkUnusualSpending(
 
       // Create notification
       const { title, message } = formatAnomalyNotification(anomaly);
+      const priority = anomaly.multiplier >= 4 ? "high" : "medium";
 
       await db.notification.create({
         data: {
@@ -111,7 +113,7 @@ export async function checkUnusualSpending(
           type: "unusual_spending",
           title,
           message,
-          priority: anomaly.multiplier >= 4 ? "high" : "medium",
+          priority,
           metadata: JSON.stringify({
             anomalyType: anomaly.type,
             cooldownKey,
@@ -125,6 +127,14 @@ export async function checkUnusualSpending(
           }),
         },
       });
+
+      // Send push notification
+      sendPushForNotification(userId, {
+        type: "unusual_spending",
+        title,
+        message,
+        priority,
+      }).catch(() => {}); // fire-and-forget
 
       return true; // Created at least one notification
     }

--- a/src/lib/execute-scheduled-transfer.ts
+++ b/src/lib/execute-scheduled-transfer.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { fetchExchangeRate } from "@/lib/exchange-rate";
 import { calculateNextExecution } from "@/lib/schedule";
 import { checkLowBalance } from "@/lib/check-low-balance";
+import { sendPushForNotification } from "@/lib/push-notifications";
 
 export interface ExecutionResult {
   scheduleId: string;
@@ -165,15 +166,18 @@ export async function executeScheduledTransfer(
     message += ` Next execution: ${nextExecution.toLocaleDateString()}.`;
   }
 
+  const title = `Scheduled transfer executed: ${fromName} → ${toName}`;
+  const priority = "medium";
+
   db.notification
     .create({
       data: {
         userId,
         spaceId: schedule.fromAccount.spaceId,
         type: "transfer_confirmation",
-        title: `Scheduled transfer executed: ${fromName} → ${toName}`,
+        title,
         message,
-        priority: "medium",
+        priority,
         metadata: JSON.stringify({
           scheduleId: schedule.id,
           transactionId: result.id,
@@ -185,6 +189,15 @@ export async function executeScheduledTransfer(
           deactivated,
         }),
       },
+    })
+    .then(() => {
+      // Send push notification after in-app notification is created
+      sendPushForNotification(userId, {
+        type: "transfer_confirmation",
+        title,
+        message,
+        priority,
+      }).catch(() => {});
     })
     .catch(() => {});
 

--- a/src/lib/push-client.ts
+++ b/src/lib/push-client.ts
@@ -1,0 +1,163 @@
+/**
+ * Client-side push notification utilities.
+ * Handles service worker registration, permission requests, and subscription management.
+ */
+
+/**
+ * Check if push notifications are supported in this browser.
+ */
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+/**
+ * Get the current push notification permission state.
+ */
+export function getPushPermission(): NotificationPermission | "unsupported" {
+  if (!isPushSupported()) return "unsupported";
+  return Notification.permission;
+}
+
+/**
+ * Register the service worker if not already registered.
+ */
+async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration> {
+  const registration = await navigator.serviceWorker.register("/sw.js");
+  await navigator.serviceWorker.ready;
+  return registration;
+}
+
+/**
+ * Convert a URL-safe base64 string to a Uint8Array for applicationServerKey.
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const outputArray = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    outputArray[i] = raw.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/**
+ * Subscribe the current browser to push notifications.
+ * Returns true if subscription was successful.
+ */
+export async function subscribeToPush(): Promise<boolean> {
+  if (!isPushSupported()) {
+    throw new Error("Push notifications are not supported in this browser");
+  }
+
+  // Request notification permission
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    return false;
+  }
+
+  try {
+    // Get VAPID public key from server
+    const keyRes = await fetch("/api/push/vapid-key");
+    if (!keyRes.ok) {
+      throw new Error("Failed to get VAPID key");
+    }
+    const { publicKey } = await keyRes.json();
+
+    // Register service worker and subscribe
+    const registration = await getServiceWorkerRegistration();
+
+    // Check if already subscribed
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) {
+      // Re-send to server in case it was lost
+      await saveSubscription(existing);
+      return true;
+    }
+
+    const keyArray = urlBase64ToUint8Array(publicKey);
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: keyArray.buffer as ArrayBuffer,
+    });
+
+    await saveSubscription(subscription);
+    return true;
+  } catch (error) {
+    console.error("Push subscription failed:", error);
+    throw error;
+  }
+}
+
+/**
+ * Unsubscribe the current browser from push notifications.
+ */
+export async function unsubscribeFromPush(): Promise<boolean> {
+  if (!isPushSupported()) return false;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration("/sw.js");
+    if (!registration) return false;
+
+    const subscription = await registration.pushManager.getSubscription();
+    if (!subscription) return false;
+
+    // Remove from server
+    await fetch("/api/push/subscribe", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    });
+
+    // Unsubscribe locally
+    await subscription.unsubscribe();
+    return true;
+  } catch (error) {
+    console.error("Push unsubscription failed:", error);
+    throw error;
+  }
+}
+
+/**
+ * Check if the current browser is subscribed to push notifications.
+ */
+export async function isPushSubscribed(): Promise<boolean> {
+  if (!isPushSupported()) return false;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration("/sw.js");
+    if (!registration) return false;
+
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Save a push subscription to the server.
+ */
+async function saveSubscription(subscription: PushSubscription): Promise<void> {
+  const json = subscription.toJSON();
+  const res = await fetch("/api/push/subscribe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      endpoint: json.endpoint,
+      keys: {
+        p256dh: json.keys?.p256dh,
+        auth: json.keys?.auth,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to save push subscription to server");
+  }
+}

--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -1,0 +1,138 @@
+/**
+ * Web Push notification delivery.
+ * Sends browser push notifications to users with active subscriptions.
+ */
+
+import webpush from "web-push";
+import { db } from "@/lib/db";
+
+// Configure VAPID details
+const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY || "";
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || "";
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT || "mailto:admin@coinkeeper.app";
+
+if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  icon?: string;
+  badge?: string;
+  tag?: string;
+  url?: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Send a push notification to all subscribed devices for a user.
+ * Automatically cleans up invalid/expired subscriptions.
+ * Returns the number of notifications successfully sent.
+ */
+export async function sendPushNotification(
+  userId: string,
+  payload: PushPayload
+): Promise<number> {
+  if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+    console.warn("VAPID keys not configured, skipping push notification");
+    return 0;
+  }
+
+  const subscriptions = await db.pushSubscription.findMany({
+    where: { userId },
+  });
+
+  if (subscriptions.length === 0) {
+    return 0;
+  }
+
+  const jsonPayload = JSON.stringify(payload);
+  let sent = 0;
+  const staleIds: string[] = [];
+
+  for (const sub of subscriptions) {
+    try {
+      await webpush.sendNotification(
+        {
+          endpoint: sub.endpoint,
+          keys: {
+            p256dh: sub.p256dh,
+            auth: sub.auth,
+          },
+        },
+        jsonPayload,
+        { TTL: 86400 } // 24 hours
+      );
+      sent++;
+    } catch (error: unknown) {
+      const statusCode = (error as { statusCode?: number })?.statusCode;
+      // 404 or 410 means subscription is no longer valid
+      if (statusCode === 404 || statusCode === 410) {
+        staleIds.push(sub.id);
+      } else {
+        console.error(
+          `Push notification failed for subscription ${sub.id}:`,
+          error
+        );
+      }
+    }
+  }
+
+  // Clean up stale subscriptions
+  if (staleIds.length > 0) {
+    await db.pushSubscription.deleteMany({
+      where: { id: { in: staleIds } },
+    });
+  }
+
+  return sent;
+}
+
+/**
+ * Send push notification for a newly created in-app notification.
+ * Maps notification type to appropriate icon and tag.
+ */
+export async function sendPushForNotification(
+  userId: string,
+  notification: {
+    type: string;
+    title: string;
+    message: string;
+    priority: string;
+  }
+): Promise<void> {
+  const iconMap: Record<string, string> = {
+    low_balance: "⚠️",
+    unusual_spending: "📊",
+    expense_reminder: "📝",
+    transfer_confirmation: "✅",
+    system: "🔔",
+  };
+
+  try {
+    await sendPushNotification(userId, {
+      title: notification.title,
+      body: notification.message,
+      icon: "/icon-192.png",
+      badge: "/icon-badge.png",
+      tag: notification.type,
+      url: "/notifications",
+      data: {
+        type: notification.type,
+        priority: notification.priority,
+        emoji: iconMap[notification.type] || "🔔",
+      },
+    });
+  } catch (error) {
+    // Push delivery failures should not block notification creation
+    console.error("Push notification delivery failed:", error);
+  }
+}
+
+/**
+ * Get the VAPID public key for client-side subscription.
+ */
+export function getVapidPublicKey(): string {
+  return VAPID_PUBLIC_KEY;
+}


### PR DESCRIPTION
## Summary
- Adds Web Push API support for delivering browser push notifications alongside in-app notifications
- All notification types (low balance, unusual spending, expense reminders, transfer confirmations) now trigger push delivery to subscribed browsers
- Users can enable/disable push via a toggle in notification settings, with graceful handling of unsupported browsers and denied permissions

## Changes
- **Schema**: New `PushSubscription` model for storing device push subscriptions (endpoint, p256dh, auth)
- **API**: `POST/DELETE /api/push/subscribe` for subscription management, `GET /api/push/vapid-key` for client registration
- **Service worker**: `public/sw.js` handles push events and notification click navigation to `/notifications`
- **Server utility**: `sendPushForNotification()` integrated into all four notification creator functions
- **Client utility**: `push-client.ts` with subscribe/unsubscribe/permission helpers
- **UI**: Push toggle added to `NotificationSettings` component with permission state feedback

## Test plan
- [ ] Enable push notifications in settings → browser requests permission → subscription saved
- [ ] Create a transaction that triggers low balance warning → push notification received
- [ ] Click push notification → navigates to /notifications page
- [ ] Disable push in settings → push subscription removed
- [ ] Test in browser without Push API support → shows "not supported" message
- [ ] Test with permission denied → shows appropriate error message
- [ ] Verify build passes (`npm run build`) and lint is clean

Closes #97
Part of #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)