### PR TITLE
Add CSV export for transactions

### DIFF
--- a/src/app/api/transactions/export/route.ts
+++ b/src/app/api/transactions/export/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+import { getSpaceContext, getSpaceAccountIds } from "@/lib/space-context";
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+// GET /api/transactions/export — export transactions as CSV
+export async function GET(request: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const context = await getSpaceContext(user.id);
+  const { searchParams } = new URL(request.url);
+
+  const type = searchParams.get("type");
+  const accountId = searchParams.get("accountId");
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+
+  // Build where clause (same logic as GET /api/transactions)
+  const where: Record<string, unknown> = {};
+
+  if (context.spaceId) {
+    const spaceAccountIds = await getSpaceAccountIds(context.spaceId);
+    if (spaceAccountIds.length === 0) {
+      return new Response("", {
+        status: 200,
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": 'attachment; filename="transactions.csv"',
+        },
+      });
+    }
+    where.OR = [
+      { fromAccountId: { in: spaceAccountIds } },
+      { toAccountId: { in: spaceAccountIds } },
+    ];
+
+    if (accountId) {
+      if (!spaceAccountIds.includes(accountId)) {
+        return new Response("", {
+          status: 200,
+          headers: {
+            "Content-Type": "text/csv; charset=utf-8",
+            "Content-Disposition": 'attachment; filename="transactions.csv"',
+          },
+        });
+      }
+      where.OR = [{ fromAccountId: accountId }, { toAccountId: accountId }];
+    }
+  } else {
+    where.userId = user.id;
+    if (accountId) {
+      delete where.userId;
+      where.AND = [
+        { userId: user.id },
+        { OR: [{ fromAccountId: accountId }, { toAccountId: accountId }] },
+      ];
+    }
+  }
+
+  if (type) where.type = type;
+  if (from || to) {
+    where.date = {};
+    if (from) (where.date as Record<string, unknown>).gte = new Date(from);
+    if (to) (where.date as Record<string, unknown>).lte = new Date(to);
+  }
+
+  const transactions = await db.transaction.findMany({
+    where,
+    include: {
+      category: true,
+      fromAccount: { select: { id: true, name: true, currency: true } },
+      toAccount: { select: { id: true, name: true, currency: true } },
+    },
+    orderBy: { date: "desc" },
+  });
+
+  // Build CSV
+  const headers = [
+    "Date",
+    "Type",
+    "Amount",
+    "Currency",
+    "Description",
+    "Category",
+    "From Account",
+    "To Account",
+    "Exchange Rate",
+    "To Amount",
+  ];
+
+  const rows = transactions.map((txn) => [
+    new Date(txn.date).toISOString().split("T")[0],
+    txn.type,
+    txn.amount.toString(),
+    txn.currency,
+    txn.description || "",
+    txn.category?.name || "",
+    txn.fromAccount?.name || "",
+    txn.toAccount?.name || "",
+    txn.exchangeRate != null ? txn.exchangeRate.toString() : "",
+    txn.toAmount != null ? txn.toAmount.toString() : "",
+  ]);
+
+  const csvContent =
+    headers.map(escapeCsvField).join(",") +
+    "\n" +
+    rows.map((row) => row.map(escapeCsvField).join(",")).join("\n");
+
+  const today = new Date().toISOString().split("T")[0];
+  const filename = `coinkeeper-transactions-${today}.csv`;
+
+  return new Response(csvContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { getSpaceContext, getSpaceAccountIds } from "@/lib/space-context";
 import { TransactionCard } from "@/components/transaction-card";
+import { ExportButton } from "@/components/export-button";
 import Link from "next/link";
 
 export const metadata = {
@@ -109,27 +110,30 @@ export default async function TransactionsPage() {
               : `${transactions.length} transaction${transactions.length === 1 ? "" : "s"}`}
           </p>
         </div>
-        {canCreate && (
-          <Link
-            href="/transactions/new"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors"
-          >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
+        <div className="flex items-center gap-2">
+          {transactions.length > 0 && <ExportButton />}
+          {canCreate && (
+            <Link
+              href="/transactions/new"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 4.5v15m7.5-7.5h-15"
-              />
-            </svg>
-            Add Transaction
-          </Link>
-        )}
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 4.5v15m7.5-7.5h-15"
+                />
+              </svg>
+              Add Transaction
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* Transaction List */}

--- a/src/components/export-button.tsx
+++ b/src/components/export-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+
+export function ExportButton() {
+  const [loading, setLoading] = useState(false);
+
+  async function handleExport() {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/transactions/export");
+      if (!response.ok) {
+        throw new Error("Export failed");
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        response.headers
+          .get("Content-Disposition")
+          ?.match(/filename="(.+)"/)?.[1] || "transactions.csv";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      console.error("Export failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={loading}
+      className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 transition-colors disabled:opacity-50"
+    >
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={2}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+        />
+      </svg>
+      {loading ? "Exporting..." : "Export CSV"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/transactions/export` endpoint that returns CSV with proper Content-Disposition header for file download
- CSV includes: Date, Type, Amount, Currency, Description, Category, From Account, To Account, Exchange Rate, To Amount
- Supports query filters: `type`, `accountId`, `from`, `to` (same as transaction list API)
- Respects space-scoped and personal transaction context
- Add Export CSV button to transactions page (shown when transactions exist)
- Proper CSV escaping for fields containing commas, quotes, or newlines

Closes #96

## Test plan
- [ ] Navigate to /transactions with existing transactions — Export CSV button appears
- [ ] Click Export CSV — browser downloads a `.csv` file
- [ ] Open CSV in spreadsheet — all columns properly formatted
- [ ] With no transactions — Export button is hidden
- [ ] Verify CSV respects space context when in a shared space

🤖 Generated with [Claude Code](https://claude.com/claude-code)