### PR TITLE
Add CSV import for transactions

### DIFF
--- a/src/app/api/transactions/import/route.ts
+++ b/src/app/api/transactions/import/route.ts
@@ -1,0 +1,320 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+import { getSpaceContext, checkSpacePermission, getSpaceAccountIds } from "@/lib/space-context";
+
+interface ImportError {
+  row: number;
+  message: string;
+}
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++; // skip escaped quote
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ",") {
+        fields.push(current.trim());
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+  }
+  fields.push(current.trim());
+  return fields;
+}
+
+function normalizeHeader(header: string): string {
+  return header.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+// POST /api/transactions/import — import transactions from CSV
+export async function POST(request: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const context = await getSpaceContext(user.id);
+
+  // Check space permissions
+  if (context.spaceId) {
+    const perm = await checkSpacePermission(user.id, context.spaceId, "editor");
+    if (!perm.allowed) {
+      return NextResponse.json(
+        { error: "Viewers cannot import transactions in this space" },
+        { status: 403 }
+      );
+    }
+  }
+
+  // Parse multipart form data
+  const formData = await request.formData();
+  const file = formData.get("file") as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!file.name.endsWith(".csv")) {
+    return NextResponse.json({ error: "File must be a CSV" }, { status: 400 });
+  }
+
+  const text = await file.text();
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+
+  if (lines.length < 2) {
+    return NextResponse.json(
+      { error: "CSV must have a header row and at least one data row" },
+      { status: 400 }
+    );
+  }
+
+  // Parse header
+  const headerFields = parseCsvLine(lines[0]).map(normalizeHeader);
+
+  // Map column indices
+  const colMap: Record<string, number> = {};
+  const knownColumns = ["date", "type", "amount", "currency", "description", "category", "account", "fromaccount", "toaccount"];
+  for (let i = 0; i < headerFields.length; i++) {
+    const normalized = headerFields[i];
+    if (knownColumns.includes(normalized)) {
+      colMap[normalized] = i;
+    }
+  }
+
+  // Require at least date, type, amount
+  if (colMap.date === undefined || colMap.type === undefined || colMap.amount === undefined) {
+    return NextResponse.json(
+      { error: "CSV must have at least Date, Type, and Amount columns" },
+      { status: 400 }
+    );
+  }
+
+  // Load user's accounts for matching
+  let accounts;
+  if (context.spaceId) {
+    const spaceAccountIds = await getSpaceAccountIds(context.spaceId);
+    accounts = await db.account.findMany({
+      where: { id: { in: spaceAccountIds } },
+    });
+  } else {
+    accounts = await db.account.findMany({
+      where: { userId: user.id },
+    });
+  }
+
+  const accountByName = new Map(
+    accounts.map((a) => [a.name.toLowerCase(), a])
+  );
+
+  // Load user's categories for matching
+  const categories = await db.category.findMany({
+    where: { userId: user.id },
+  });
+  const categoryByName = new Map(
+    categories.map((c) => [c.name.toLowerCase(), c])
+  );
+
+  const errors: ImportError[] = [];
+  let imported = 0;
+  let skipped = 0;
+
+  // Process data rows
+  for (let i = 1; i < lines.length; i++) {
+    const fields = parseCsvLine(lines[i]);
+    const rowNum = i + 1; // 1-based for user display
+
+    try {
+      // Parse date
+      const dateStr = fields[colMap.date] || "";
+      const date = new Date(dateStr);
+      if (isNaN(date.getTime())) {
+        errors.push({ row: rowNum, message: `Invalid date: "${dateStr}"` });
+        skipped++;
+        continue;
+      }
+
+      // Parse type
+      const typeRaw = (fields[colMap.type] || "").toLowerCase();
+      const validTypes = ["expense", "income", "transfer"];
+      if (!validTypes.includes(typeRaw)) {
+        errors.push({ row: rowNum, message: `Invalid type: "${typeRaw}". Must be expense, income, or transfer` });
+        skipped++;
+        continue;
+      }
+
+      // Parse amount
+      const amountStr = fields[colMap.amount] || "";
+      const amount = parseFloat(amountStr);
+      if (isNaN(amount) || amount <= 0) {
+        errors.push({ row: rowNum, message: `Invalid amount: "${amountStr}"` });
+        skipped++;
+        continue;
+      }
+
+      const currency = (colMap.currency !== undefined ? fields[colMap.currency] : "") || "USD";
+      const description = colMap.description !== undefined ? fields[colMap.description] || "" : "";
+
+      // Resolve account
+      // Support "Account" (single), or "From Account"/"To Account" (separate)
+      let fromAccountId: string | null = null;
+      let toAccountId: string | null = null;
+
+      if (colMap.fromaccount !== undefined || colMap.toaccount !== undefined) {
+        // Separate from/to columns
+        if (colMap.fromaccount !== undefined) {
+          const name = (fields[colMap.fromaccount] || "").toLowerCase();
+          if (name) {
+            const acc = accountByName.get(name);
+            if (!acc) {
+              errors.push({ row: rowNum, message: `Unknown account: "${fields[colMap.fromaccount]}"` });
+              skipped++;
+              continue;
+            }
+            fromAccountId = acc.id;
+          }
+        }
+        if (colMap.toaccount !== undefined) {
+          const name = (fields[colMap.toaccount] || "").toLowerCase();
+          if (name) {
+            const acc = accountByName.get(name);
+            if (!acc) {
+              errors.push({ row: rowNum, message: `Unknown account: "${fields[colMap.toaccount]}"` });
+              skipped++;
+              continue;
+            }
+            toAccountId = acc.id;
+          }
+        }
+      } else if (colMap.account !== undefined) {
+        // Single account column
+        const accountName = (fields[colMap.account] || "").toLowerCase();
+        if (accountName) {
+          const acc = accountByName.get(accountName);
+          if (!acc) {
+            errors.push({ row: rowNum, message: `Unknown account: "${fields[colMap.account]}"` });
+            skipped++;
+            continue;
+          }
+          if (typeRaw === "expense") {
+            fromAccountId = acc.id;
+          } else if (typeRaw === "income") {
+            toAccountId = acc.id;
+          }
+        }
+      }
+
+      // Validate account requirements
+      if (typeRaw === "expense" && !fromAccountId) {
+        errors.push({ row: rowNum, message: "Expense requires an account (From Account or Account column)" });
+        skipped++;
+        continue;
+      }
+      if (typeRaw === "income" && !toAccountId) {
+        errors.push({ row: rowNum, message: "Income requires an account (To Account or Account column)" });
+        skipped++;
+        continue;
+      }
+      if (typeRaw === "transfer" && (!fromAccountId || !toAccountId)) {
+        errors.push({ row: rowNum, message: "Transfer requires both From Account and To Account" });
+        skipped++;
+        continue;
+      }
+
+      // Resolve category (create if needed)
+      let categoryId: string | null = null;
+      const categoryName = colMap.category !== undefined ? fields[colMap.category] || "" : "";
+      if (categoryName) {
+        const existing = categoryByName.get(categoryName.toLowerCase());
+        if (existing) {
+          categoryId = existing.id;
+        } else {
+          // Create new category
+          const newCat = await db.category.create({
+            data: {
+              name: categoryName,
+              userId: user.id,
+            },
+          });
+          categoryByName.set(categoryName.toLowerCase(), newCat);
+          categoryId = newCat.id;
+        }
+      }
+
+      // Create transaction and update balance
+      await db.$transaction(async (tx) => {
+        await tx.transaction.create({
+          data: {
+            userId: user.id,
+            type: typeRaw,
+            amount,
+            currency,
+            description: description || null,
+            date,
+            categoryId,
+            fromAccountId,
+            toAccountId,
+            exchangeRate: typeRaw === "transfer" ? 1 : null,
+            toAmount: typeRaw === "transfer" ? amount : null,
+          },
+        });
+
+        // Update balances
+        if (typeRaw === "expense" && fromAccountId) {
+          await tx.account.update({
+            where: { id: fromAccountId },
+            data: { balance: { decrement: amount } },
+          });
+        } else if (typeRaw === "income" && toAccountId) {
+          await tx.account.update({
+            where: { id: toAccountId },
+            data: { balance: { increment: amount } },
+          });
+        } else if (typeRaw === "transfer") {
+          if (fromAccountId) {
+            await tx.account.update({
+              where: { id: fromAccountId },
+              data: { balance: { decrement: amount } },
+            });
+          }
+          if (toAccountId) {
+            await tx.account.update({
+              where: { id: toAccountId },
+              data: { balance: { increment: amount } },
+            });
+          }
+        }
+      });
+
+      imported++;
+    } catch (err) {
+      errors.push({ row: rowNum, message: `Unexpected error: ${err instanceof Error ? err.message : "unknown"}` });
+      skipped++;
+    }
+  }
+
+  return NextResponse.json({
+    imported,
+    skipped,
+    total: lines.length - 1,
+    errors: errors.slice(0, 50), // Limit error details
+  });
+}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/auth";
 import { getSpaceContext, getSpaceAccountIds } from "@/lib/space-context";
 import { TransactionCard } from "@/components/transaction-card";
 import { ExportButton } from "@/components/export-button";
+import { ImportButton } from "@/components/import-button";
 import Link from "next/link";
 
 export const metadata = {
@@ -111,6 +112,7 @@ export default async function TransactionsPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {canCreate && <ImportButton />}
           {transactions.length > 0 && <ExportButton />}
           {canCreate && (
             <Link

--- a/src/components/import-button.tsx
+++ b/src/components/import-button.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface ImportResult {
+  imported: number;
+  skipped: number;
+  total: number;
+  errors: { row: number; message: string }[];
+}
+
+export function ImportButton() {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setLoading(true);
+    setResult(null);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const response = await fetch("/api/transactions/import", {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || "Import failed");
+      } else {
+        setResult(data);
+        // Reload to show new transactions
+        if (data.imported > 0) {
+          setTimeout(() => window.location.reload(), 2000);
+        }
+      }
+    } catch {
+      setError("Import failed. Please try again.");
+    } finally {
+      setLoading(false);
+      // Reset file input
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="relative">
+      <label
+        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 transition-colors cursor-pointer ${loading ? "opacity-50 pointer-events-none" : ""}`}
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+          />
+        </svg>
+        {loading ? "Importing..." : "Import CSV"}
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </label>
+
+      {/* Result toast */}
+      {(result || error) && (
+        <div className="absolute right-0 top-full mt-2 z-50 w-80 p-4 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+          {error && (
+            <div className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </div>
+          )}
+          {result && (
+            <div className="space-y-2">
+              <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Import Complete
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-300">
+                <span className="text-emerald-600 dark:text-emerald-400 font-medium">
+                  {result.imported}
+                </span>{" "}
+                imported
+                {result.skipped > 0 && (
+                  <>
+                    {" / "}
+                    <span className="text-amber-600 dark:text-amber-400 font-medium">
+                      {result.skipped}
+                    </span>{" "}
+                    skipped
+                  </>
+                )}
+                {" / "}
+                {result.total} total
+              </div>
+              {result.errors.length > 0 && (
+                <div className="mt-2 max-h-32 overflow-y-auto text-xs text-gray-500 dark:text-gray-400 space-y-1">
+                  {result.errors.slice(0, 10).map((err, i) => (
+                    <div key={i}>
+                      Row {err.row}: {err.message}
+                    </div>
+                  ))}
+                  {result.errors.length > 10 && (
+                    <div>...and {result.errors.length - 10} more errors</div>
+                  )}
+                </div>
+              )}
+              {result.imported > 0 && (
+                <div className="text-xs text-gray-400 dark:text-gray-500">
+                  Page will refresh...
+                </div>
+              )}
+            </div>
+          )}
+          <button
+            onClick={() => {
+              setResult(null);
+              setError(null);
+            }}
+            className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/transactions/import` endpoint accepting CSV file upload via multipart form data
- Parses CSV with proper quote/escape handling
- Supports flexible column mapping: Date, Type, Amount, Currency, Description, Category, Account (or From Account/To Account)
- Matches account names case-insensitively to existing accounts
- Auto-creates new categories when CSV references unknown category names
- Updates account balances atomically per transaction
- Returns import summary: imported count, skipped count, and detailed per-row errors
- Add Import CSV button with file picker and result toast to transactions page
- Respects space context and role-based permissions

Closes #100

## Test plan
- [ ] Upload a valid CSV with expense/income rows — transactions created correctly
- [ ] Upload CSV with unknown account name — rows skipped with clear error
- [ ] Upload CSV with new category name — category auto-created
- [ ] Import summary toast shows correct counts
- [ ] Page refreshes after successful import
- [ ] Verify account balances updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)