### PR TITLE
Add natural language transaction entry

### DIFF
--- a/src/app/api/transactions/parse-natural/route.ts
+++ b/src/app/api/transactions/parse-natural/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { parseNaturalLanguage } from "@/lib/parse-natural";
+import { categorizeTransaction } from "@/lib/categorize";
+import { db } from "@/lib/db";
+
+// POST /api/transactions/parse-natural — parse natural language into transaction fields
+export async function POST(request: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { text } = body;
+
+  if (!text || typeof text !== "string" || text.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Text is required" },
+      { status: 400 }
+    );
+  }
+
+  if (text.length > 500) {
+    return NextResponse.json(
+      { error: "Text must be 500 characters or less" },
+      { status: 400 }
+    );
+  }
+
+  // Parse the natural language text
+  const parsed = await parseNaturalLanguage(text.trim());
+
+  // Try to match a category using the AI categorization system
+  const categories = await db.category.findMany({
+    where: { userId: user.id },
+    select: { id: true, name: true },
+  });
+
+  let categoryId: string | null = null;
+  let categoryName: string | null = null;
+
+  if (parsed.description && categories.length > 0) {
+    const catResult = await categorizeTransaction(
+      parsed.suggestedCategory || parsed.description,
+      categories,
+      parsed.amount || undefined
+    );
+    categoryId = catResult.categoryId;
+    categoryName = catResult.suggestedName;
+  }
+
+  return NextResponse.json({
+    type: parsed.type,
+    amount: parsed.amount,
+    currency: parsed.currency,
+    description: parsed.description,
+    source: parsed.source || null,
+    date: parsed.date || null,
+    categoryId,
+    categoryName,
+    originalText: text.trim(),
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { formatMoney, accountTypeLabel } from "@/lib/format";
 import { NetWorthSummary } from "@/components/net-worth-summary";
+import { QuickAdd } from "@/components/quick-add";
 import { getSpaceContext } from "@/lib/space-context";
 
 export const dynamic = "force-dynamic";
@@ -133,6 +134,21 @@ export default async function Dashboard() {
             </div>
           )}
         </section>
+
+        {/* Quick Add — Natural Language Entry */}
+        {hasAccounts && canEdit && (
+          <section>
+            <QuickAdd
+              accounts={accounts.map((a) => ({
+                id: a.id,
+                name: a.name,
+                type: a.type,
+                currency: a.currency,
+                balance: a.balance,
+              }))}
+            />
+          </section>
+        )}
 
         {/* Quick Actions */}
         {hasAccounts && canEdit && (

--- a/src/components/quick-add.tsx
+++ b/src/components/quick-add.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { formatMoney } from "@/lib/format";
+
+interface Account {
+  id: string;
+  name: string;
+  type: string;
+  currency: string;
+  balance: number;
+}
+
+interface ParsedResult {
+  type: "expense" | "income" | "transfer";
+  amount: number;
+  currency: string;
+  description: string;
+  source: string | null;
+  date: string | null;
+  categoryId: string | null;
+  categoryName: string | null;
+  originalText: string;
+}
+
+export function QuickAdd({ accounts }: { accounts: Account[] }) {
+  const [text, setText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [parsed, setParsed] = useState<ParsedResult | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const handleParse = async () => {
+    if (!text.trim()) return;
+    setLoading(true);
+    setError(null);
+    setParsed(null);
+    setSuccess(null);
+
+    try {
+      const res = await fetch("/api/transactions/parse-natural", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: text.trim() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to parse");
+        return;
+      }
+
+      const data: ParsedResult = await res.json();
+      setParsed(data);
+
+      // Auto-select first matching account by currency
+      if (accounts.length > 0) {
+        const currencyMatch = accounts.find(
+          (a) => a.currency === data.currency
+        );
+        setSelectedAccountId(
+          currencyMatch?.id || accounts[0].id
+        );
+      }
+    } catch {
+      setError("Failed to parse transaction. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!parsed || !selectedAccountId) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const body: Record<string, unknown> = {
+        type: parsed.type,
+        amount: parsed.amount,
+        currency: parsed.currency,
+        description: parsed.description,
+        categoryId: parsed.categoryId,
+        date: parsed.date || new Date().toISOString(),
+      };
+
+      if (parsed.type === "expense") {
+        body.fromAccountId = selectedAccountId;
+      } else if (parsed.type === "income") {
+        body.toAccountId = selectedAccountId;
+        if (parsed.source) body.source = parsed.source;
+      }
+
+      const res = await fetch("/api/transactions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to create transaction");
+        return;
+      }
+
+      setSuccess(
+        `${parsed.type === "income" ? "Income" : "Expense"} of ${formatMoney(parsed.amount, parsed.currency)} added!`
+      );
+      setText("");
+      setParsed(null);
+      setSelectedAccountId("");
+      router.refresh();
+
+      // Auto-clear success after 3s
+      setTimeout(() => setSuccess(null), 3000);
+    } catch {
+      setError("Failed to create transaction. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !parsed) {
+      e.preventDefault();
+      handleParse();
+    }
+  };
+
+  const handleCancel = () => {
+    setParsed(null);
+    setError(null);
+    inputRef.current?.focus();
+  };
+
+  const typeLabel =
+    parsed?.type === "income"
+      ? "Income"
+      : parsed?.type === "transfer"
+        ? "Transfer"
+        : "Expense";
+  const typeColor =
+    parsed?.type === "income"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : parsed?.type === "transfer"
+        ? "text-blue-600 dark:text-blue-400"
+        : "text-red-600 dark:text-red-400";
+  const typeBg =
+    parsed?.type === "income"
+      ? "bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800"
+      : parsed?.type === "transfer"
+        ? "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800"
+        : "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800";
+
+  return (
+    <div className="space-y-3">
+      {/* Input bar */}
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder='Quick add: "coffee $5.50" or "salary 3000 EUR"'
+            disabled={loading}
+            className="w-full rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-600 focus:border-transparent disabled:opacity-50"
+          />
+          {loading && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <div className="w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+        </div>
+        <button
+          onClick={handleParse}
+          disabled={!text.trim() || loading}
+          className="px-4 py-3 rounded-xl bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+        >
+          {loading ? "Parsing..." : "Parse"}
+        </button>
+      </div>
+
+      {/* Success message */}
+      {success && (
+        <div className="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-300 flex items-center gap-2">
+          <span>✓</span>
+          {success}
+        </div>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <div className="rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Parsed result card */}
+      {parsed && (
+        <div
+          className={`rounded-xl border p-4 space-y-3 ${typeBg}`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span
+                className={`text-xs font-semibold uppercase tracking-wider ${typeColor}`}
+              >
+                {typeLabel}
+              </span>
+              {parsed.categoryName && (
+                <span className="text-xs text-gray-500 dark:text-gray-400 bg-white/60 dark:bg-gray-800/60 rounded-full px-2 py-0.5">
+                  {parsed.categoryName}
+                </span>
+              )}
+            </div>
+            <span className={`text-lg font-bold tabular-nums ${typeColor}`}>
+              {parsed.type === "expense" ? "-" : parsed.type === "income" ? "+" : ""}
+              {formatMoney(parsed.amount, parsed.currency)}
+            </span>
+          </div>
+
+          {/* Description */}
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {parsed.description}
+            {parsed.source && (
+              <span className="text-gray-500 dark:text-gray-400">
+                {" "}
+                · from {parsed.source}
+              </span>
+            )}
+            {parsed.date && (
+              <span className="text-gray-500 dark:text-gray-400">
+                {" "}
+                ·{" "}
+                {new Date(parsed.date + "T00:00:00").toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", year: "numeric" }
+                )}
+              </span>
+            )}
+          </p>
+
+          {/* Account selector + actions */}
+          {parsed.type !== "transfer" && (
+            <div className="flex items-center gap-2">
+              <select
+                value={selectedAccountId}
+                onChange={(e) => setSelectedAccountId(e.target.value)}
+                className="flex-1 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              >
+                <option value="">Select account</option>
+                {accounts.map((acc) => (
+                  <option key={acc.id} value={acc.id}>
+                    {acc.name} ({acc.currency}) — {formatMoney(acc.balance, acc.currency)}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={handleSubmit}
+                disabled={!selectedAccountId || submitting || parsed.amount <= 0}
+                className="px-4 py-2 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submitting ? "Adding..." : "Confirm"}
+              </button>
+              <button
+                onClick={handleCancel}
+                className="px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {/* Transfer note */}
+          {parsed.type === "transfer" && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              For transfers, please use the{" "}
+              <a
+                href="/transfers/new"
+                className="text-emerald-600 dark:text-emerald-400 underline"
+              >
+                transfer form
+              </a>{" "}
+              to select source and destination accounts.
+            </p>
+          )}
+
+          {parsed.amount <= 0 && (
+            <p className="text-xs text-red-500">
+              Could not detect an amount. Please include a number in your text.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/parse-natural.ts
+++ b/src/lib/parse-natural.ts
@@ -1,0 +1,179 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+export interface ParsedTransaction {
+  type: "expense" | "income" | "transfer";
+  amount: number;
+  currency: string;
+  description: string;
+  source?: string; // for income
+  suggestedCategory?: string;
+  date?: string; // ISO date if mentioned
+}
+
+const SYSTEM_PROMPT = `You are a financial transaction parser. Given a natural language description of a transaction, extract structured data.
+
+Rules:
+- Determine the type: "expense" (spending money), "income" (receiving money), or "transfer" (moving between accounts)
+- Keywords indicating expense: "spent", "paid", "bought", "cost", "for", or just an item with price
+- Keywords indicating income: "earned", "received", "got paid", "salary", "paycheck", "income"
+- Keywords indicating transfer: "transfer", "moved", "sent to account"
+- Extract the amount as a positive number
+- Detect currency from symbols ($, €, £) or codes (USD, EUR, GBP, etc.). Default to "USD" if unclear
+- Extract a concise description of what the transaction is for
+- For income, extract the source (employer, client, etc.) if mentioned
+- Suggest a category name (short, 2-3 words, Title Case) that best describes the transaction
+- If a date is mentioned (e.g. "yesterday", "last Friday", "March 15"), convert to ISO format. Use the current date context provided. If no date mentioned, omit the field.
+
+Respond with ONLY valid JSON:
+{"type": "expense"|"income"|"transfer", "amount": number, "currency": "USD", "description": "string", "source": "string"|null, "suggestedCategory": "string", "date": "YYYY-MM-DD"|null}`;
+
+function buildPrompt(text: string): string {
+  const today = new Date().toISOString().split("T")[0];
+  return `Today is ${today}. Parse this transaction:\n\n"${text}"`;
+}
+
+/**
+ * Parse natural language text into structured transaction data using AI.
+ * Falls back to regex parsing if AI is unavailable.
+ */
+export async function parseNaturalLanguage(
+  text: string
+): Promise<ParsedTransaction> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (apiKey) {
+    try {
+      const client = new Anthropic({ apiKey });
+      const message = await client.messages.create({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 200,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: buildPrompt(text) }],
+      });
+
+      const textBlock = message.content.find((b) => b.type === "text");
+      if (textBlock && textBlock.type === "text") {
+        const parsed = JSON.parse(textBlock.text);
+        return {
+          type: parsed.type || "expense",
+          amount: typeof parsed.amount === "number" && parsed.amount > 0 ? parsed.amount : 0,
+          currency: parsed.currency || "USD",
+          description: parsed.description || text,
+          source: parsed.source || undefined,
+          suggestedCategory: parsed.suggestedCategory || undefined,
+          date: parsed.date || undefined,
+        };
+      }
+    } catch (error) {
+      console.error("AI natural language parsing failed:", error);
+    }
+  }
+
+  // Fallback: regex-based parsing
+  return parseWithRegex(text);
+}
+
+/**
+ * Regex fallback parser for when AI is unavailable.
+ * Extracts amount, currency, and basic description from text.
+ */
+export function parseWithRegex(text: string): ParsedTransaction {
+  const normalized = text.trim();
+
+  // Detect type from keywords
+  let type: "expense" | "income" | "transfer" = "expense";
+  const lowerText = normalized.toLowerCase();
+  if (
+    lowerText.includes("earned") ||
+    lowerText.includes("received") ||
+    lowerText.includes("got paid") ||
+    lowerText.includes("salary") ||
+    lowerText.includes("paycheck") ||
+    lowerText.includes("income")
+  ) {
+    type = "income";
+  } else if (
+    lowerText.includes("transfer") ||
+    lowerText.includes("moved to")
+  ) {
+    type = "transfer";
+  }
+
+  // Extract currency and amount
+  // Match patterns like: $25, 25$, 25 USD, €15.50, 15.50 EUR, etc.
+  let currency = "USD";
+  let amount = 0;
+
+  // Currency symbol before amount: $25.50, €15, £100
+  const symbolBeforeMatch = normalized.match(
+    /([€£¥₹]|\$)\s*(\d+(?:[.,]\d{1,2})?)/
+  );
+  // Currency symbol after amount: 25$, 15€
+  const symbolAfterMatch = normalized.match(
+    /(\d+(?:[.,]\d{1,2})?)\s*([€£¥₹$])/
+  );
+  // Currency code: 25 USD, 100 EUR, EUR 50
+  const codeAfterMatch = normalized.match(
+    /(\d+(?:[.,]\d{1,2})?)\s*(USD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|SEK|NOK|DKK|PLN|CZK|HUF|RUB|TRY|BRL|MXN|INR|CNY|KRW|SGD|HKD|TWD|THB|MYR|IDR|PHP|VND|ZAR|ILS|AED|SAR)/i
+  );
+  const codeBeforeMatch = normalized.match(
+    /(USD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|SEK|NOK|DKK|PLN|CZK|HUF|RUB|TRY|BRL|MXN|INR|CNY|KRW|SGD|HKD|TWD|THB|MYR|IDR|PHP|VND|ZAR|ILS|AED|SAR)\s*(\d+(?:[.,]\d{1,2})?)/i
+  );
+  // Plain number
+  const plainNumber = normalized.match(/(\d+(?:[.,]\d{1,2})?)/);
+
+  const currencySymbols: Record<string, string> = {
+    $: "USD",
+    "€": "EUR",
+    "£": "GBP",
+    "¥": "JPY",
+    "₹": "INR",
+  };
+
+  if (symbolBeforeMatch) {
+    currency = currencySymbols[symbolBeforeMatch[1]] || "USD";
+    amount = parseFloat(symbolBeforeMatch[2].replace(",", "."));
+  } else if (symbolAfterMatch) {
+    currency = currencySymbols[symbolAfterMatch[2]] || "USD";
+    amount = parseFloat(symbolAfterMatch[1].replace(",", "."));
+  } else if (codeAfterMatch) {
+    amount = parseFloat(codeAfterMatch[1].replace(",", "."));
+    currency = codeAfterMatch[2].toUpperCase();
+  } else if (codeBeforeMatch) {
+    currency = codeBeforeMatch[1].toUpperCase();
+    amount = parseFloat(codeBeforeMatch[2].replace(",", "."));
+  } else if (plainNumber) {
+    amount = parseFloat(plainNumber[1].replace(",", "."));
+  }
+
+  // Extract description: remove amount/currency parts
+  let description = normalized
+    .replace(/[€£¥₹$]\s*\d+(?:[.,]\d{1,2})?/, "")
+    .replace(/\d+(?:[.,]\d{1,2})?\s*[€£¥₹$]/, "")
+    .replace(
+      /\d+(?:[.,]\d{1,2})?\s*(USD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|SEK|NOK|DKK|PLN|CZK|HUF|RUB|TRY|BRL|MXN|INR|CNY|KRW|SGD|HKD|TWD|THB|MYR|IDR|PHP|VND|ZAR|ILS|AED|SAR)/gi,
+      ""
+    )
+    .replace(
+      /(USD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|SEK|NOK|DKK|PLN|CZK|HUF|RUB|TRY|BRL|MXN|INR|CNY|KRW|SGD|HKD|TWD|THB|MYR|IDR|PHP|VND|ZAR|ILS|AED|SAR)\s*\d+(?:[.,]\d{1,2})?/gi,
+      ""
+    )
+    .replace(/\d+(?:[.,]\d{1,2})?/, "")
+    .replace(
+      /\b(spent|paid|bought|earned|received|got paid|for|on|at)\b/gi,
+      ""
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!description) {
+    description = type === "income" ? "Income" : "Expense";
+  }
+
+  return {
+    type,
+    amount,
+    currency,
+    description,
+  };
+}


### PR DESCRIPTION
## Summary
- Add AI-powered natural language parsing for transactions via a new quick-add bar on the dashboard
- Users type free-form text (e.g. "coffee $5.50", "salary 3000 EUR", "spent 25 on groceries at Walmart") and the system extracts amount, currency, type, description, and suggests a category
- Falls back to regex-based parsing when Claude API is unavailable
- Parsed results show in a confirmation card with account selection before creating the transaction

### New files
- `src/lib/parse-natural.ts` — AI + regex transaction parser
- `src/app/api/transactions/parse-natural/route.ts` — API endpoint for parsing
- `src/components/quick-add.tsx` — Dashboard quick-add client component

### Modified files
- `src/app/page.tsx` — Integrated QuickAdd component into dashboard

## Test plan
- [ ] Type "coffee $5.50" → should parse as expense, $5.50, description "coffee"
- [ ] Type "salary 3000 EUR" → should parse as income, €3,000, source "salary"
- [ ] Type "25 groceries" → should parse as expense, $25, description "groceries"
- [ ] Select account and click Confirm → transaction created, dashboard refreshes
- [ ] Cancel button dismisses the parsed result
- [ ] Invalid input (no amount) shows error in confirmation card
- [ ] Works without ANTHROPIC_API_KEY (regex fallback)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)