### PR TITLE
Add multi-currency aggregation with rate history charts

### DIFF
--- a/prisma/migrations/20260326184843_add_reminder_days/migration.sql
+++ b/prisma/migrations/20260326184843_add_reminder_days/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "reminderDays" INTEGER;

--- a/prisma/migrations/20260326210252_add_base_currency_and_rate_history/migration.sql
+++ b/prisma/migrations/20260326210252_add_base_currency_and_rate_history/migration.sql
@@ -1,0 +1,37 @@
+-- CreateTable
+CREATE TABLE "ExchangeRateHistory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "fromCurrency" TEXT NOT NULL,
+    "toCurrency" TEXT NOT NULL,
+    "rate" REAL NOT NULL,
+    "date" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "reminderDays" INTEGER,
+    "baseCurrency" TEXT NOT NULL DEFAULT 'USD',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "name", "reminderDays", "updatedAt") SELECT "createdAt", "email", "id", "name", "reminderDays", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "ExchangeRateHistory_fromCurrency_toCurrency_idx" ON "ExchangeRateHistory"("fromCurrency", "toCurrency");
+
+-- CreateIndex
+CREATE INDEX "ExchangeRateHistory_date_idx" ON "ExchangeRateHistory"("date");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExchangeRateHistory_fromCurrency_toCurrency_date_key" ON "ExchangeRateHistory"("fromCurrency", "toCurrency", "date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   name         String
   email        String   @unique
   reminderDays Int?     // days without transactions before reminder (null = disabled)
+  baseCurrency String   @default("USD") // preferred base currency for net worth display
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -350,4 +351,19 @@ model SpaceMember {
 
   @@unique([userId, spaceId])
   @@index([spaceId])
+}
+
+// ─── Exchange Rate History ──────────────────────────────────────────
+
+model ExchangeRateHistory {
+  id         String   @id @default(cuid())
+  fromCurrency String
+  toCurrency   String
+  rate         Float
+  date         DateTime // date the rate was recorded (truncated to day)
+  createdAt    DateTime @default(now())
+
+  @@unique([fromCurrency, toCurrency, date])
+  @@index([fromCurrency, toCurrency])
+  @@index([date])
 }

--- a/src/app/api/exchange-rates/history/route.ts
+++ b/src/app/api/exchange-rates/history/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/auth";
+import { getHistoricalRates, fetchExchangeRate } from "@/lib/exchange-rate";
+
+/**
+ * GET /api/exchange-rates/history?from=USD&to=EUR&days=30
+ *
+ * Returns historical exchange rate data for charting.
+ * Also fetches the current rate to ensure today's data is recorded.
+ */
+export async function GET(req: NextRequest) {
+  const { error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const searchParams = req.nextUrl.searchParams;
+  const from = searchParams.get("from")?.toUpperCase();
+  const to = searchParams.get("to")?.toUpperCase();
+  const days = parseInt(searchParams.get("days") || "30", 10);
+
+  if (!from || !to) {
+    return NextResponse.json(
+      { error: "Both 'from' and 'to' currency parameters are required" },
+      { status: 400 }
+    );
+  }
+
+  if (from.length !== 3 || to.length !== 3) {
+    return NextResponse.json(
+      { error: "Currency codes must be 3 letters" },
+      { status: 400 }
+    );
+  }
+
+  if (isNaN(days) || days < 1 || days > 365) {
+    return NextResponse.json(
+      { error: "Days must be between 1 and 365" },
+      { status: 400 }
+    );
+  }
+
+  // Fetch current rate to ensure today's data is captured
+  const currentRate = await fetchExchangeRate(from, to);
+
+  // Get historical data
+  const history = await getHistoricalRates(from, to, days);
+
+  return NextResponse.json({
+    from,
+    to,
+    days,
+    currentRate,
+    history,
+  });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -13,10 +13,13 @@ export async function GET() {
 
   const fullUser = await db.user.findUnique({
     where: { id: user.id },
-    select: { reminderDays: true },
+    select: { reminderDays: true, baseCurrency: true },
   });
 
-  return NextResponse.json({ reminderDays: fullUser?.reminderDays ?? null });
+  return NextResponse.json({
+    reminderDays: fullUser?.reminderDays ?? null,
+    baseCurrency: fullUser?.baseCurrency ?? "USD",
+  });
 }
 
 /**
@@ -29,27 +32,44 @@ export async function PATCH(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { reminderDays } = body;
+  const { reminderDays, baseCurrency } = body;
+
+  // Build update data
+  const data: Record<string, unknown> = {};
 
   // Validate reminderDays
-  if (reminderDays !== null && reminderDays !== undefined) {
-    const days = parseInt(reminderDays, 10);
-    if (isNaN(days) || days < 1) {
-      return NextResponse.json(
-        { error: "Reminder days must be a positive integer or null" },
-        { status: 400 }
-      );
+  if (reminderDays !== undefined) {
+    if (reminderDays !== null) {
+      const days = parseInt(reminderDays, 10);
+      if (isNaN(days) || days < 1) {
+        return NextResponse.json(
+          { error: "Reminder days must be a positive integer or null" },
+          { status: 400 }
+        );
+      }
+      data.reminderDays = days;
+    } else {
+      data.reminderDays = null;
     }
   }
 
-  await db.user.update({
-    where: { id: user.id },
-    data: {
-      reminderDays: reminderDays !== null && reminderDays !== undefined
-        ? parseInt(reminderDays, 10)
-        : null,
-    },
-  });
+  // Validate baseCurrency
+  if (baseCurrency !== undefined) {
+    if (typeof baseCurrency !== "string" || baseCurrency.length !== 3) {
+      return NextResponse.json(
+        { error: "Base currency must be a 3-letter ISO currency code" },
+        { status: 400 }
+      );
+    }
+    data.baseCurrency = baseCurrency.toUpperCase();
+  }
+
+  if (Object.keys(data).length > 0) {
+    await db.user.update({
+      where: { id: user.id },
+      data,
+    });
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/currencies/page.tsx
+++ b/src/app/currencies/page.tsx
@@ -1,0 +1,46 @@
+import { requireUser } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { CurrencyRateChart } from "@/components/currency-rate-chart";
+import { BaseCurrencySettings } from "@/components/base-currency-settings";
+
+export default async function CurrenciesPage() {
+  const user = await requireUser();
+
+  // Get user's base currency and unique currencies from their accounts
+  const [fullUser, accounts] = await Promise.all([
+    db.user.findUnique({
+      where: { id: user.id },
+      select: { baseCurrency: true },
+    }),
+    db.account.findMany({
+      where: { userId: user.id, isArchived: false },
+      select: { currency: true },
+      distinct: ["currency"],
+    }),
+  ]);
+
+  const baseCurrency = fullUser?.baseCurrency ?? "USD";
+  const userCurrencies = [...new Set(accounts.map((a) => a.currency))];
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+        Currencies
+      </h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+        Track exchange rates and manage your base currency preference.
+      </p>
+
+      <div className="space-y-8">
+        {/* Base currency preference */}
+        <BaseCurrencySettings initialBaseCurrency={baseCurrency} />
+
+        {/* Exchange rate chart */}
+        <CurrencyRateChart
+          baseCurrency={baseCurrency}
+          userCurrencies={userCurrencies}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,6 +2,7 @@ import { requireUser } from "@/lib/auth";
 import { TelegramLinkCard } from "@/components/telegram-link-card";
 import { getTelegramLinkStatus } from "@/lib/telegram";
 import { NotificationSettings } from "@/components/notification-settings";
+import { BaseCurrencySettings } from "@/components/base-currency-settings";
 import { db } from "@/lib/db";
 
 export default async function SettingsPage() {
@@ -11,7 +12,7 @@ export default async function SettingsPage() {
   const botConfigured = !!process.env.TELEGRAM_BOT_TOKEN;
   const fullUser = await db.user.findUnique({
     where: { id: user.id },
-    select: { reminderDays: true },
+    select: { reminderDays: true, baseCurrency: true },
   });
 
   return (
@@ -37,6 +38,11 @@ export default async function SettingsPage() {
             </div>
           </dl>
         </div>
+
+        {/* Base currency preference */}
+        <BaseCurrencySettings
+          initialBaseCurrency={fullUser?.baseCurrency ?? "USD"}
+        />
 
         {/* Notifications section */}
         <NotificationSettings

--- a/src/components/base-currency-settings.tsx
+++ b/src/components/base-currency-settings.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+
+const CURRENCIES = [
+  "USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "CNY",
+  "RUB", "INR", "BRL", "KRW", "MXN", "SGD", "HKD", "NOK",
+  "SEK", "DKK", "NZD", "ZAR", "TRY", "PLN", "CZK", "THB", "UAH",
+];
+
+export function BaseCurrencySettings({
+  initialBaseCurrency,
+}: {
+  initialBaseCurrency: string;
+}) {
+  const [baseCurrency, setBaseCurrency] = useState(initialBaseCurrency);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleChange = async (newCurrency: string) => {
+    setBaseCurrency(newCurrency);
+    setSaving(true);
+    setSaved(false);
+
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ baseCurrency: newCurrency }),
+      });
+
+      if (res.ok) {
+        // Also update localStorage for backward compatibility with NetWorthSummary
+        localStorage.setItem("coinkeeper-base-currency", newCurrency);
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      }
+    } catch {
+      // Revert on error
+      setBaseCurrency(initialBaseCurrency);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+        Base Currency
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Your preferred currency for net worth display and conversions.
+      </p>
+
+      <div className="flex items-center gap-3">
+        <select
+          value={baseCurrency}
+          onChange={(e) => handleChange(e.target.value)}
+          disabled={saving}
+          className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 disabled:opacity-50"
+        >
+          {CURRENCIES.map((cur) => (
+            <option key={cur} value={cur}>
+              {cur}
+            </option>
+          ))}
+        </select>
+
+        {saving && (
+          <span className="text-xs text-gray-400 flex items-center gap-1">
+            <span className="w-3 h-3 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+            Saving...
+          </span>
+        )}
+
+        {saved && (
+          <span className="text-xs text-emerald-600 dark:text-emerald-400">
+            Saved
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/currency-rate-chart.tsx
+++ b/src/components/currency-rate-chart.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+const ALL_CURRENCIES = [
+  "USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "CNY",
+  "RUB", "INR", "BRL", "KRW", "MXN", "SGD", "HKD", "NOK",
+  "SEK", "DKK", "NZD", "ZAR", "TRY", "PLN", "CZK", "THB", "UAH",
+];
+
+const DATE_RANGES = [
+  { label: "7d", days: 7 },
+  { label: "30d", days: 30 },
+  { label: "90d", days: 90 },
+];
+
+interface RateDataPoint {
+  date: string;
+  rate: number;
+}
+
+interface HistoryResponse {
+  from: string;
+  to: string;
+  days: number;
+  currentRate: number | null;
+  history: RateDataPoint[];
+}
+
+export function CurrencyRateChart({
+  baseCurrency,
+  userCurrencies,
+}: {
+  baseCurrency: string;
+  userCurrencies: string[];
+}) {
+  // Default "from" is base currency, "to" is first user currency that differs
+  const defaultTo =
+    userCurrencies.find((c) => c !== baseCurrency) ||
+    (baseCurrency === "USD" ? "EUR" : "USD");
+
+  const [from, setFrom] = useState(baseCurrency);
+  const [to, setTo] = useState(defaultTo);
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState<HistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchHistory = useCallback(async () => {
+    if (from === to) return;
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/exchange-rates/history?from=${from}&to=${to}&days=${days}`
+      );
+      if (res.ok) {
+        const json: HistoryResponse = await res.json();
+        setData(json);
+      }
+    } catch {
+      // Silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, [from, to, days]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  const swapCurrencies = () => {
+    setFrom(to);
+    setTo(from);
+  };
+
+  const formatRate = (rate: number) => {
+    if (rate >= 1000) return rate.toFixed(0);
+    if (rate >= 100) return rate.toFixed(2);
+    if (rate >= 1) return rate.toFixed(4);
+    return rate.toFixed(6);
+  };
+
+  // Compute min/max for Y axis domain
+  const allRates = data?.history?.map((d) => d.rate) ?? [];
+  if (data?.currentRate) allRates.push(data.currentRate);
+  const minRate = allRates.length > 0 ? Math.min(...allRates) : 0;
+  const maxRate = allRates.length > 0 ? Math.max(...allRates) : 1;
+  const padding = (maxRate - minRate) * 0.1 || 0.01;
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        Exchange Rate Chart
+      </h2>
+
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <div className="flex items-center gap-2">
+          <select
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-emerald-500"
+          >
+            {ALL_CURRENCIES.map((cur) => (
+              <option key={cur} value={cur} disabled={cur === to}>
+                {cur}
+              </option>
+            ))}
+          </select>
+
+          <button
+            onClick={swapCurrencies}
+            className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            title="Swap currencies"
+          >
+            <svg
+              className="w-4 h-4 text-gray-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+              />
+            </svg>
+          </button>
+
+          <select
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1.5 text-sm text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-emerald-500"
+          >
+            {ALL_CURRENCIES.map((cur) => (
+              <option key={cur} value={cur} disabled={cur === from}>
+                {cur}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Date range selector */}
+        <div className="flex rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden">
+          {DATE_RANGES.map((range) => (
+            <button
+              key={range.days}
+              onClick={() => setDays(range.days)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                days === range.days
+                  ? "bg-emerald-500 text-white"
+                  : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-750"
+              }`}
+            >
+              {range.label}
+            </button>
+          ))}
+        </div>
+
+        {loading && (
+          <div className="w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+        )}
+      </div>
+
+      {/* Current rate display */}
+      {from === to ? (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          Select two different currencies to see exchange rates.
+        </div>
+      ) : data?.currentRate ? (
+        <>
+          <div className="mb-6">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Current rate
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-gray-100">
+              1 {from} = {formatRate(data.currentRate)} {to}
+            </p>
+          </div>
+
+          {/* Chart */}
+          {data.history.length > 1 ? (
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={data.history}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--color-gray-200, #e5e7eb)"
+                  />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={(val: string) => {
+                      const d = new Date(val + "T00:00:00");
+                      return d.toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      });
+                    }}
+                  />
+                  <YAxis
+                    domain={[minRate - padding, maxRate + padding]}
+                    tick={{ fontSize: 11 }}
+                    tickFormatter={(val: number) => formatRate(val)}
+                    width={70}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "var(--color-gray-50, #f9fafb)",
+                      border: "1px solid var(--color-gray-200, #e5e7eb)",
+                      borderRadius: "8px",
+                      fontSize: "12px",
+                    }}
+                    labelFormatter={(val) => {
+                      const d = new Date(String(val) + "T00:00:00");
+                      return d.toLocaleDateString("en-US", {
+                        weekday: "short",
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      });
+                    }}
+                    formatter={(value) => [
+                      formatRate(Number(value)),
+                      `${from}/${to}`,
+                    ]}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="rate"
+                    stroke="#10b981"
+                    strokeWidth={2}
+                    dot={data.history.length <= 14}
+                    activeDot={{ r: 5 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400 text-sm">
+              <p>Not enough historical data to display a chart yet.</p>
+              <p className="mt-1 text-xs">
+                Rate data is collected daily as you use the app. Check back in a
+                few days to see trends.
+              </p>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          Unable to fetch exchange rate for {from}/{to}. Try again later.
+        </div>
+      )}
+
+      {/* User currencies hint */}
+      {userCurrencies.length > 1 && (
+        <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Your account currencies:{" "}
+            {userCurrencies.map((c, i) => (
+              <button
+                key={c}
+                onClick={() => {
+                  if (c !== from) setTo(c);
+                }}
+                className="font-mono font-medium text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                {c}
+                {i < userCurrencies.length - 1 ? ", " : ""}
+              </button>
+            ))}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -97,6 +97,12 @@ export async function Nav() {
             Prices
           </Link>
           <Link
+            href="/currencies"
+            className="px-3 py-1.5 rounded-lg text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            Currencies
+          </Link>
+          <Link
             href="/analytics"
             className="px-3 py-1.5 rounded-lg text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >

--- a/src/components/net-worth-summary.tsx
+++ b/src/components/net-worth-summary.tsx
@@ -39,12 +39,28 @@ export function NetWorthSummary() {
   const [loading, setLoading] = useState(true);
   const [showBreakdown, setShowBreakdown] = useState(false);
 
-  // Load saved preference
+  // Load saved preference — try DB first, fall back to localStorage
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved && POPULAR_CURRENCIES.includes(saved)) {
-      setBaseCurrency(saved);
+    async function loadPreference() {
+      try {
+        const res = await fetch("/api/settings");
+        if (res.ok) {
+          const settings = await res.json();
+          if (settings.baseCurrency) {
+            setBaseCurrency(settings.baseCurrency);
+            localStorage.setItem(STORAGE_KEY, settings.baseCurrency);
+            return;
+          }
+        }
+      } catch {
+        // Fall back to localStorage
+      }
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved && POPULAR_CURRENCIES.includes(saved)) {
+        setBaseCurrency(saved);
+      }
     }
+    loadPreference();
   }, []);
 
   const fetchNetWorth = useCallback(async (currency: string) => {
@@ -66,9 +82,20 @@ export function NetWorthSummary() {
     fetchNetWorth(baseCurrency);
   }, [baseCurrency, fetchNetWorth]);
 
-  const handleCurrencyChange = (newCurrency: string) => {
+  const handleCurrencyChange = async (newCurrency: string) => {
     setBaseCurrency(newCurrency);
     localStorage.setItem(STORAGE_KEY, newCurrency);
+
+    // Persist to DB
+    try {
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ baseCurrency: newCurrency }),
+      });
+    } catch {
+      // localStorage is the fallback
+    }
   };
 
   if (loading && !data) {

--- a/src/lib/exchange-rate.ts
+++ b/src/lib/exchange-rate.ts
@@ -1,7 +1,10 @@
 /**
  * Shared exchange rate utility.
  * Uses https://api.exchangerate-api.com/v4/latest/{currency} (free, no key).
+ * Persists fetched rates to ExchangeRateHistory for historical tracking.
  */
+
+import { db } from "@/lib/db";
 
 // Cache exchange rates for 10 minutes to avoid excessive API calls
 const rateCache = new Map<string, { rate: number; fetchedAt: number }>();
@@ -34,8 +37,80 @@ export async function fetchExchangeRate(
     if (typeof rate !== "number") return null;
 
     rateCache.set(cacheKey, { rate, fetchedAt: Date.now() });
+
+    // Persist to history (fire and forget, don't block the response)
+    persistRateHistory(fromUpper, toUpper, rate).catch(() => {});
+
     return rate;
   } catch {
     return null;
   }
+}
+
+/**
+ * Store a rate snapshot in ExchangeRateHistory (one per currency pair per day).
+ */
+async function persistRateHistory(
+  fromCurrency: string,
+  toCurrency: string,
+  rate: number
+): Promise<void> {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  await db.exchangeRateHistory.upsert({
+    where: {
+      fromCurrency_toCurrency_date: {
+        fromCurrency,
+        toCurrency,
+        date: today,
+      },
+    },
+    update: { rate },
+    create: { fromCurrency, toCurrency, rate, date: today },
+  });
+}
+
+/**
+ * Fetch historical rates for a currency pair over a date range.
+ */
+export async function getHistoricalRates(
+  from: string,
+  to: string,
+  days: number = 30
+): Promise<{ date: string; rate: number }[]> {
+  const fromUpper = from.toUpperCase();
+  const toUpper = to.toUpperCase();
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+  since.setHours(0, 0, 0, 0);
+
+  const records = await db.exchangeRateHistory.findMany({
+    where: {
+      fromCurrency: fromUpper,
+      toCurrency: toUpper,
+      date: { gte: since },
+    },
+    orderBy: { date: "asc" },
+    select: { date: true, rate: true },
+  });
+
+  return records.map((r) => ({
+    date: r.date.toISOString().split("T")[0],
+    rate: r.rate,
+  }));
+}
+
+/**
+ * Seed historical rates by fetching from external API.
+ * This fetches the current rate and stores it — useful for bootstrapping history.
+ * Called on-demand from the currencies page API.
+ */
+export async function seedCurrentRate(
+  from: string,
+  to: string
+): Promise<number | null> {
+  const rate = await fetchExchangeRate(from, to);
+  return rate;
 }


### PR DESCRIPTION
## Summary

- **Persistent base currency preference**: stored in DB (User.baseCurrency field) instead of just localStorage, synced across sessions and devices
- **Exchange rate history tracking**: rates are automatically persisted to an ExchangeRateHistory table daily as users interact with the app
- **Currencies page** (`/currencies`): interactive Recharts line chart showing exchange rate trends with currency pair selector and 7d/30d/90d date ranges
- **Settings integration**: base currency selector added to both `/settings` and `/currencies` pages

Closes #17

## Changes

| File | Description |
|------|-------------|
| `prisma/schema.prisma` | Add `baseCurrency` to User, new `ExchangeRateHistory` model |
| `src/lib/exchange-rate.ts` | Persist rates to DB on fetch, add `getHistoricalRates()` |
| `src/app/api/exchange-rates/history/route.ts` | New API for historical rate data |
| `src/app/api/settings/route.ts` | Support `baseCurrency` in GET/PATCH |
| `src/app/currencies/page.tsx` | New currencies page |
| `src/components/currency-rate-chart.tsx` | Interactive line chart with pair selector |
| `src/components/base-currency-settings.tsx` | Reusable base currency picker |
| `src/components/net-worth-summary.tsx` | Load preference from DB, save to DB on change |
| `src/components/nav.tsx` | Add Currencies nav link |
| `src/app/settings/page.tsx` | Add BaseCurrencySettings section |

## Test plan

- [ ] Set base currency in settings — verify it persists after page reload
- [ ] Visit /currencies — verify current exchange rate displays
- [ ] Select different currency pairs and date ranges
- [ ] Check that rates accumulate in history over multiple days
- [ ] Verify NetWorthSummary on dashboard reads base currency from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)