### PR TITLE
feat: SavedReport model + CRUD API for custom reports

### DIFF
--- a/prisma/migrations/20260326220500_add_saved_reports/migration.sql
+++ b/prisma/migrations/20260326220500_add_saved_reports/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "SavedReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "format" TEXT NOT NULL DEFAULT 'csv',
+    "filters" TEXT NOT NULL,
+    "lastRunAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SavedReport_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "SavedReport_userId_idx" ON "SavedReport"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   products         Product[]
   notifications    Notification[]
   pushSubscriptions PushSubscription[]
+  savedReports     SavedReport[]
 }
 
 // ─── WebAuthn Credentials ────────────────────────────────────────────
@@ -351,6 +352,24 @@ model SpaceMember {
 
   @@unique([userId, spaceId])
   @@index([spaceId])
+}
+
+// ─── Saved Reports ─────────────────────────────────────────────────
+
+model SavedReport {
+  id          String   @id @default(cuid())
+  userId      String
+  name        String
+  description String?
+  format      String   @default("csv") // csv, json
+  filters     String   // JSON: { type?, accountId?, categoryId?, from?, to?, periodPreset? }
+  lastRunAt   DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 // ─── Exchange Rate History ──────────────────────────────────────────

--- a/src/app/api/reports/[id]/generate/route.ts
+++ b/src/app/api/reports/[id]/generate/route.ts
@@ -1,0 +1,289 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+import { getSpaceContext, getSpaceAccountIds } from "@/lib/space-context";
+
+interface ReportFilters {
+  type?: string;
+  accountId?: string;
+  categoryId?: string;
+  from?: string;
+  to?: string;
+  periodPreset?: string; // 7d, 30d, 90d, 1y, all
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function resolvePeriodPreset(preset: string): { from: Date; to: Date } {
+  const now = new Date();
+  const to = now;
+  let from: Date;
+
+  switch (preset) {
+    case "7d":
+      from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case "30d":
+      from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+    case "90d":
+      from = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+      break;
+    case "1y":
+      from = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+      break;
+    default:
+      from = new Date(0); // all time
+  }
+
+  return { from, to };
+}
+
+// POST /api/reports/[id]/generate — execute a saved report and return data
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const report = await db.savedReport.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  const filters: ReportFilters = JSON.parse(report.filters);
+  const context = await getSpaceContext(user.id);
+
+  // Build where clause
+  const where: Record<string, unknown> = {};
+
+  if (context.spaceId) {
+    const spaceAccountIds = await getSpaceAccountIds(context.spaceId);
+    if (spaceAccountIds.length === 0) {
+      return returnEmpty(report.format, report.name);
+    }
+    where.OR = [
+      { fromAccountId: { in: spaceAccountIds } },
+      { toAccountId: { in: spaceAccountIds } },
+    ];
+
+    if (filters.accountId) {
+      if (!spaceAccountIds.includes(filters.accountId)) {
+        return returnEmpty(report.format, report.name);
+      }
+      where.OR = [
+        { fromAccountId: filters.accountId },
+        { toAccountId: filters.accountId },
+      ];
+    }
+  } else {
+    where.userId = user.id;
+    if (filters.accountId) {
+      delete where.userId;
+      where.AND = [
+        { userId: user.id },
+        {
+          OR: [
+            { fromAccountId: filters.accountId },
+            { toAccountId: filters.accountId },
+          ],
+        },
+      ];
+    }
+  }
+
+  if (filters.type) {
+    where.type = filters.type;
+  }
+
+  if (filters.categoryId) {
+    where.categoryId = filters.categoryId;
+  }
+
+  // Date range: use explicit dates or period preset
+  if (filters.from || filters.to) {
+    where.date = {};
+    if (filters.from)
+      (where.date as Record<string, unknown>).gte = new Date(filters.from);
+    if (filters.to)
+      (where.date as Record<string, unknown>).lte = new Date(filters.to);
+  } else if (filters.periodPreset && filters.periodPreset !== "all") {
+    const { from, to } = resolvePeriodPreset(filters.periodPreset);
+    where.date = { gte: from, lte: to };
+  }
+
+  const transactions = await db.transaction.findMany({
+    where,
+    include: {
+      category: true,
+      fromAccount: { select: { id: true, name: true, currency: true } },
+      toAccount: { select: { id: true, name: true, currency: true } },
+    },
+    orderBy: { date: "desc" },
+  });
+
+  // Update lastRunAt
+  await db.savedReport.update({
+    where: { id },
+    data: { lastRunAt: new Date() },
+  });
+
+  // Compute summary
+  const summary = {
+    totalTransactions: transactions.length,
+    totalExpenses: 0,
+    totalIncome: 0,
+    totalTransfers: 0,
+    netAmount: 0,
+  };
+
+  for (const txn of transactions) {
+    if (txn.type === "expense") summary.totalExpenses += txn.amount;
+    else if (txn.type === "income") summary.totalIncome += txn.amount;
+    else if (txn.type === "transfer") summary.totalTransfers += txn.amount;
+  }
+  summary.netAmount = summary.totalIncome - summary.totalExpenses;
+
+  if (report.format === "csv") {
+    return generateCsv(transactions, report.name);
+  }
+
+  // JSON format
+  return NextResponse.json({
+    report: {
+      id: report.id,
+      name: report.name,
+      generatedAt: new Date().toISOString(),
+      filters,
+    },
+    summary: {
+      ...summary,
+      totalExpenses: Math.round(summary.totalExpenses * 100) / 100,
+      totalIncome: Math.round(summary.totalIncome * 100) / 100,
+      totalTransfers: Math.round(summary.totalTransfers * 100) / 100,
+      netAmount: Math.round(summary.netAmount * 100) / 100,
+    },
+    transactions: transactions.map((txn) => ({
+      date: new Date(txn.date).toISOString().split("T")[0],
+      type: txn.type,
+      amount: txn.amount,
+      currency: txn.currency,
+      description: txn.description || "",
+      source: txn.source || "",
+      category: txn.category?.name || "",
+      fromAccount: txn.fromAccount?.name || "",
+      toAccount: txn.toAccount?.name || "",
+      exchangeRate: txn.exchangeRate,
+      toAmount: txn.toAmount,
+    })),
+  });
+}
+
+function returnEmpty(format: string, name: string) {
+  if (format === "csv") {
+    const headers =
+      "Date,Type,Amount,Currency,Description,Category,From Account,To Account,Exchange Rate,To Amount";
+    const filename = `${slugify(name)}-${today()}.csv`;
+    return new Response(headers, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  }
+  return NextResponse.json({
+    report: { name, generatedAt: new Date().toISOString() },
+    summary: {
+      totalTransactions: 0,
+      totalExpenses: 0,
+      totalIncome: 0,
+      totalTransfers: 0,
+      netAmount: 0,
+    },
+    transactions: [],
+  });
+}
+
+function generateCsv(
+  transactions: Array<{
+    date: Date;
+    type: string;
+    amount: number;
+    currency: string;
+    description: string | null;
+    category: { name: string } | null;
+    fromAccount: { name: string } | null;
+    toAccount: { name: string } | null;
+    exchangeRate: number | null;
+    toAmount: number | null;
+  }>,
+  reportName: string
+) {
+  const headers = [
+    "Date",
+    "Type",
+    "Amount",
+    "Currency",
+    "Description",
+    "Category",
+    "From Account",
+    "To Account",
+    "Exchange Rate",
+    "To Amount",
+  ];
+
+  const rows = transactions.map((txn) =>
+    [
+      new Date(txn.date).toISOString().split("T")[0],
+      txn.type,
+      txn.amount.toString(),
+      txn.currency,
+      txn.description || "",
+      txn.category?.name || "",
+      txn.fromAccount?.name || "",
+      txn.toAccount?.name || "",
+      txn.exchangeRate != null ? txn.exchangeRate.toString() : "",
+      txn.toAmount != null ? txn.toAmount.toString() : "",
+    ]
+      .map(escapeCsvField)
+      .join(",")
+  );
+
+  const csvContent =
+    headers.map(escapeCsvField).join(",") + "\n" + rows.join("\n");
+
+  const filename = `${slugify(reportName)}-${today()}.csv`;
+
+  return new Response(csvContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function today(): string {
+  return new Date().toISOString().split("T")[0];
+}

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+
+// GET /api/reports/[id] — get a single saved report
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const report = await db.savedReport.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ...report,
+    filters: JSON.parse(report.filters),
+  });
+}
+
+// PATCH /api/reports/[id] — update a saved report
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const existing = await db.savedReport.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const data: Record<string, unknown> = {};
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string" || body.name.trim().length === 0) {
+      return NextResponse.json(
+        { error: "Name cannot be empty" },
+        { status: 400 }
+      );
+    }
+    data.name = body.name.trim();
+  }
+
+  if (body.description !== undefined) {
+    data.description = body.description?.trim() || null;
+  }
+
+  if (body.format !== undefined) {
+    const validFormats = ["csv", "json"];
+    if (!validFormats.includes(body.format)) {
+      return NextResponse.json(
+        { error: "Invalid format. Must be csv or json" },
+        { status: 400 }
+      );
+    }
+    data.format = body.format;
+  }
+
+  if (body.filters !== undefined) {
+    if (typeof body.filters !== "object") {
+      return NextResponse.json(
+        { error: "Filters must be an object" },
+        { status: 400 }
+      );
+    }
+    data.filters = JSON.stringify(body.filters);
+  }
+
+  const updated = await db.savedReport.update({
+    where: { id },
+    data,
+  });
+
+  return NextResponse.json({
+    ...updated,
+    filters: JSON.parse(updated.filters),
+  });
+}
+
+// DELETE /api/reports/[id] — delete a saved report
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const existing = await db.savedReport.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  await db.savedReport.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+
+// GET /api/reports — list user's saved reports
+export async function GET() {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const reports = await db.savedReport.findMany({
+    where: { userId: user.id },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return NextResponse.json(
+    reports.map((r) => ({
+      ...r,
+      filters: JSON.parse(r.filters),
+    }))
+  );
+}
+
+// POST /api/reports — create a new saved report
+export async function POST(request: NextRequest) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { name, description, format, filters } = body;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Name is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!filters || typeof filters !== "object") {
+    return NextResponse.json(
+      { error: "Filters object is required" },
+      { status: 400 }
+    );
+  }
+
+  const validFormats = ["csv", "json"];
+  const reportFormat = validFormats.includes(format) ? format : "csv";
+
+  const report = await db.savedReport.create({
+    data: {
+      userId: user.id,
+      name: name.trim(),
+      description: description?.trim() || null,
+      format: reportFormat,
+      filters: JSON.stringify(filters),
+    },
+  });
+
+  return NextResponse.json(
+    { ...report, filters: JSON.parse(report.filters) },
+    { status: 201 }
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SavedReport` Prisma model for storing user-configurable report templates (filter combinations, name, format)
- Full CRUD API: `GET/POST /api/reports`, `GET/PATCH/DELETE /api/reports/[id]`
- Report generation endpoint: `POST /api/reports/[id]/generate` — executes saved filters and returns transaction data as CSV or JSON with summary stats
- Supports filters: transaction type, account, category, date range (explicit or preset like 7d/30d/90d/1y/all)
- Space-aware filtering built in

Closes #104

## Test plan
- [ ] Create a saved report via POST /api/reports with various filters
- [ ] List reports via GET /api/reports
- [ ] Update a report via PATCH /api/reports/[id]
- [ ] Generate CSV output via POST /api/reports/[id]/generate
- [ ] Generate JSON output (change format to json, then generate)
- [ ] Delete a report via DELETE /api/reports/[id]
- [ ] Verify unauthorized access returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)