### PR TITLE
feat: add scheduled report generation (#107)

### DIFF
--- a/prisma/migrations/20260327010328_add_scheduled_reports/migration.sql
+++ b/prisma/migrations/20260327010328_add_scheduled_reports/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable
+CREATE TABLE "GeneratedReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "reportId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "format" TEXT NOT NULL,
+    "data" BLOB NOT NULL,
+    "summary" TEXT,
+    "fileName" TEXT,
+    "generatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" DATETIME,
+    CONSTRAINT "GeneratedReport_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "SavedReport" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GeneratedReport_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_SavedReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "format" TEXT NOT NULL DEFAULT 'csv',
+    "filters" TEXT NOT NULL,
+    "lastRunAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "scheduleEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "scheduleFrequency" TEXT,
+    "scheduleDay" INTEGER,
+    "scheduleTime" TEXT,
+    "nextRunAt" DATETIME,
+    "lastGeneratedAt" DATETIME,
+    CONSTRAINT "SavedReport_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_SavedReport" ("createdAt", "description", "filters", "format", "id", "lastRunAt", "name", "updatedAt", "userId") SELECT "createdAt", "description", "filters", "format", "id", "lastRunAt", "name", "updatedAt", "userId" FROM "SavedReport";
+DROP TABLE "SavedReport";
+ALTER TABLE "new_SavedReport" RENAME TO "SavedReport";
+CREATE INDEX "SavedReport_userId_idx" ON "SavedReport"("userId");
+CREATE INDEX "SavedReport_scheduleEnabled_nextRunAt_idx" ON "SavedReport"("scheduleEnabled", "nextRunAt");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "GeneratedReport_reportId_idx" ON "GeneratedReport"("reportId");
+
+-- CreateIndex
+CREATE INDEX "GeneratedReport_userId_idx" ON "GeneratedReport"("userId");
+
+-- CreateIndex
+CREATE INDEX "GeneratedReport_expiresAt_idx" ON "GeneratedReport"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   notifications    Notification[]
   pushSubscriptions PushSubscription[]
   savedReports     SavedReport[]
+  generatedReports GeneratedReport[]
 }
 
 // ─── WebAuthn Credentials ────────────────────────────────────────────
@@ -361,15 +362,44 @@ model SavedReport {
   userId      String
   name        String
   description String?
-  format      String   @default("csv") // csv, json
+  format      String   @default("csv") // csv, json, pdf
   filters     String   // JSON: { type?, accountId?, categoryId?, from?, to?, periodPreset? }
   lastRunAt   DateTime?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Scheduling
+  scheduleEnabled   Boolean  @default(false)
+  scheduleFrequency String?  // daily, weekly, monthly
+  scheduleDay       Int?     // day of week (0-6) for weekly, day of month (1-31) for monthly
+  scheduleTime      String?  // HH:MM display hint
+  nextRunAt         DateTime?
+  lastGeneratedAt   DateTime?
+
+  user             User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  generatedReports GeneratedReport[]
 
   @@index([userId])
+  @@index([scheduleEnabled, nextRunAt])
+}
+
+model GeneratedReport {
+  id          String   @id @default(cuid())
+  reportId    String
+  userId      String
+  format      String   // csv, json, pdf
+  data        Bytes    // generated file content
+  summary     String?  // JSON summary stats
+  fileName    String?
+  generatedAt DateTime @default(now())
+  expiresAt   DateTime? // auto-cleanup after 30 days
+
+  report SavedReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  user   User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([reportId])
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 // ─── Exchange Rate History ──────────────────────────────────────────

--- a/src/app/api/reports/[id]/generated/[genId]/route.ts
+++ b/src/app/api/reports/[id]/generated/[genId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+
+// GET /api/reports/[id]/generated/[genId] — download a generated report file
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; genId: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, genId } = await params;
+
+  const generated = await db.generatedReport.findFirst({
+    where: { id: genId, reportId: id, userId: user.id },
+  });
+
+  if (!generated) {
+    return NextResponse.json(
+      { error: "Generated report not found" },
+      { status: 404 }
+    );
+  }
+
+  const contentTypes: Record<string, string> = {
+    csv: "text/csv; charset=utf-8",
+    json: "application/json; charset=utf-8",
+    pdf: "application/pdf",
+  };
+
+  const contentType = contentTypes[generated.format] || "application/octet-stream";
+  const fileName = generated.fileName || `report.${generated.format}`;
+
+  return new Response(new Uint8Array(generated.data), {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": `attachment; filename="${fileName}"`,
+    },
+  });
+}
+
+// DELETE /api/reports/[id]/generated/[genId] — delete a generated report
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; genId: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, genId } = await params;
+
+  const generated = await db.generatedReport.findFirst({
+    where: { id: genId, reportId: id, userId: user.id },
+  });
+
+  if (!generated) {
+    return NextResponse.json(
+      { error: "Generated report not found" },
+      { status: 404 }
+    );
+  }
+
+  await db.generatedReport.delete({ where: { id: genId } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/reports/[id]/generated/route.ts
+++ b/src/app/api/reports/[id]/generated/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+
+// GET /api/reports/[id]/generated — list generated report files
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Verify ownership
+  const report = await db.savedReport.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  const generated = await db.generatedReport.findMany({
+    where: { reportId: id, userId: user.id },
+    orderBy: { generatedAt: "desc" },
+    select: {
+      id: true,
+      format: true,
+      fileName: true,
+      summary: true,
+      generatedAt: true,
+      expiresAt: true,
+    },
+  });
+
+  return NextResponse.json(
+    generated.map((g) => ({
+      ...g,
+      summary: g.summary ? JSON.parse(g.summary) : null,
+    }))
+  );
+}

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { calculateNextRunAt } from "@/lib/report-schedule";
 
 // GET /api/reports/[id] — get a single saved report
 export async function GET(
@@ -84,6 +85,36 @@ export async function PATCH(
       );
     }
     data.filters = JSON.stringify(body.filters);
+  }
+
+  // Handle schedule fields
+  if (body.scheduleEnabled !== undefined) {
+    data.scheduleEnabled = !!body.scheduleEnabled;
+    if (body.scheduleEnabled) {
+      if (body.scheduleFrequency !== undefined) data.scheduleFrequency = body.scheduleFrequency;
+      if (body.scheduleDay !== undefined) data.scheduleDay = body.scheduleDay;
+      if (body.scheduleTime !== undefined) data.scheduleTime = body.scheduleTime;
+      // Recalculate nextRunAt
+      const freq = body.scheduleFrequency ?? existing.scheduleFrequency ?? "daily";
+      const day = body.scheduleDay ?? existing.scheduleDay;
+      data.nextRunAt = calculateNextRunAt(freq, day);
+    } else {
+      // Disable: clear schedule fields
+      data.scheduleFrequency = null;
+      data.scheduleDay = null;
+      data.scheduleTime = null;
+      data.nextRunAt = null;
+    }
+  } else if (body.scheduleFrequency !== undefined || body.scheduleDay !== undefined) {
+    // Update schedule params without toggling enabled/disabled
+    if (body.scheduleFrequency !== undefined) data.scheduleFrequency = body.scheduleFrequency;
+    if (body.scheduleDay !== undefined) data.scheduleDay = body.scheduleDay;
+    if (body.scheduleTime !== undefined) data.scheduleTime = body.scheduleTime;
+    if (existing.scheduleEnabled) {
+      const freq = (body.scheduleFrequency ?? existing.scheduleFrequency) as string;
+      const day = body.scheduleDay ?? existing.scheduleDay;
+      data.nextRunAt = calculateNextRunAt(freq, day);
+    }
   }
 
   const updated = await db.savedReport.update({

--- a/src/app/api/reports/execute-scheduled/route.ts
+++ b/src/app/api/reports/execute-scheduled/route.ts
@@ -1,0 +1,412 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { requireApiUser } from "@/lib/auth";
+import { calculateNextRunAt } from "@/lib/report-schedule";
+import { getSpaceContext, getSpaceAccountIds } from "@/lib/space-context";
+import PDFDocument from "pdfkit";
+
+interface ReportFilters {
+  type?: string;
+  accountId?: string;
+  categoryId?: string;
+  from?: string;
+  to?: string;
+  periodPreset?: string;
+}
+
+function resolvePeriodPreset(preset: string): { from: Date; to: Date } {
+  const now = new Date();
+  const to = now;
+  let from: Date;
+
+  switch (preset) {
+    case "7d":
+      from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case "30d":
+      from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+    case "90d":
+      from = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+      break;
+    case "1y":
+      from = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+      break;
+    default:
+      from = new Date(0);
+  }
+
+  return { from, to };
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function today(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+// POST /api/reports/execute-scheduled — execute all due scheduled reports
+export async function POST() {
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+
+  // Find all due reports for this user
+  const dueReports = await db.savedReport.findMany({
+    where: {
+      userId: user.id,
+      scheduleEnabled: true,
+      nextRunAt: { lte: now },
+    },
+  });
+
+  if (dueReports.length === 0) {
+    return NextResponse.json({ executed: 0, errors: 0, details: [] });
+  }
+
+  const details: Array<{
+    reportId: string;
+    name: string;
+    status: "success" | "error";
+    error?: string;
+  }> = [];
+
+  for (const report of dueReports) {
+    try {
+      const filters: ReportFilters = JSON.parse(report.filters);
+      const context = await getSpaceContext(user.id);
+
+      // Build where clause (same logic as generate endpoint)
+      const where: Record<string, unknown> = {};
+
+      if (context.spaceId) {
+        const spaceAccountIds = await getSpaceAccountIds(context.spaceId);
+        if (spaceAccountIds.length > 0) {
+          where.OR = [
+            { fromAccountId: { in: spaceAccountIds } },
+            { toAccountId: { in: spaceAccountIds } },
+          ];
+          if (filters.accountId && spaceAccountIds.includes(filters.accountId)) {
+            where.OR = [
+              { fromAccountId: filters.accountId },
+              { toAccountId: filters.accountId },
+            ];
+          }
+        }
+      } else {
+        where.userId = user.id;
+        if (filters.accountId) {
+          delete where.userId;
+          where.AND = [
+            { userId: user.id },
+            {
+              OR: [
+                { fromAccountId: filters.accountId },
+                { toAccountId: filters.accountId },
+              ],
+            },
+          ];
+        }
+      }
+
+      if (filters.type) where.type = filters.type;
+      if (filters.categoryId) where.categoryId = filters.categoryId;
+
+      if (filters.from || filters.to) {
+        where.date = {};
+        if (filters.from)
+          (where.date as Record<string, unknown>).gte = new Date(filters.from);
+        if (filters.to)
+          (where.date as Record<string, unknown>).lte = new Date(filters.to);
+      } else if (filters.periodPreset && filters.periodPreset !== "all") {
+        const { from, to } = resolvePeriodPreset(filters.periodPreset);
+        where.date = { gte: from, lte: to };
+      }
+
+      const transactions = await db.transaction.findMany({
+        where,
+        include: {
+          category: true,
+          fromAccount: { select: { id: true, name: true, currency: true } },
+          toAccount: { select: { id: true, name: true, currency: true } },
+        },
+        orderBy: { date: "desc" },
+      });
+
+      // Compute summary
+      const summary = {
+        totalTransactions: transactions.length,
+        totalExpenses: 0,
+        totalIncome: 0,
+        totalTransfers: 0,
+        netAmount: 0,
+      };
+
+      for (const txn of transactions) {
+        if (txn.type === "expense") summary.totalExpenses += txn.amount;
+        else if (txn.type === "income") summary.totalIncome += txn.amount;
+        else if (txn.type === "transfer") summary.totalTransfers += txn.amount;
+      }
+      summary.netAmount = summary.totalIncome - summary.totalExpenses;
+
+      // Generate file data based on format
+      let fileData: Buffer;
+      const fileName = `${slugify(report.name)}-${today()}.${report.format}`;
+
+      if (report.format === "csv") {
+        const headers = [
+          "Date", "Type", "Amount", "Currency", "Description", "Category",
+          "From Account", "To Account", "Exchange Rate", "To Amount",
+        ];
+        const rows = transactions.map((txn) =>
+          [
+            new Date(txn.date).toISOString().split("T")[0],
+            txn.type,
+            txn.amount.toString(),
+            txn.currency,
+            txn.description || "",
+            txn.category?.name || "",
+            txn.fromAccount?.name || "",
+            txn.toAccount?.name || "",
+            txn.exchangeRate != null ? txn.exchangeRate.toString() : "",
+            txn.toAmount != null ? txn.toAmount.toString() : "",
+          ]
+            .map(escapeCsvField)
+            .join(",")
+        );
+        const csvContent =
+          headers.map(escapeCsvField).join(",") + "\n" + rows.join("\n");
+        fileData = Buffer.from(csvContent, "utf-8");
+      } else if (report.format === "pdf") {
+        fileData = await generatePdfBuffer(transactions, summary, report.name);
+      } else {
+        // JSON
+        const jsonContent = JSON.stringify(
+          {
+            report: { id: report.id, name: report.name, generatedAt: now.toISOString(), filters },
+            summary: {
+              ...summary,
+              totalExpenses: Math.round(summary.totalExpenses * 100) / 100,
+              totalIncome: Math.round(summary.totalIncome * 100) / 100,
+              totalTransfers: Math.round(summary.totalTransfers * 100) / 100,
+              netAmount: Math.round(summary.netAmount * 100) / 100,
+            },
+            transactions: transactions.map((txn) => ({
+              date: new Date(txn.date).toISOString().split("T")[0],
+              type: txn.type,
+              amount: txn.amount,
+              currency: txn.currency,
+              description: txn.description || "",
+              category: txn.category?.name || "",
+              fromAccount: txn.fromAccount?.name || "",
+              toAccount: txn.toAccount?.name || "",
+            })),
+          },
+          null,
+          2
+        );
+        fileData = Buffer.from(jsonContent, "utf-8");
+      }
+
+      // Store generated report and advance schedule
+      const expiresAt = new Date(now);
+      expiresAt.setDate(expiresAt.getDate() + 30);
+
+      const nextRunAt = calculateNextRunAt(
+        report.scheduleFrequency || "daily",
+        report.scheduleDay
+      );
+
+      await db.$transaction([
+        db.generatedReport.create({
+          data: {
+            reportId: report.id,
+            userId: user.id,
+            format: report.format,
+            data: new Uint8Array(fileData.buffer, fileData.byteOffset, fileData.byteLength) as Uint8Array<ArrayBuffer>,
+            summary: JSON.stringify(summary),
+            fileName,
+            expiresAt,
+          },
+        }),
+        db.savedReport.update({
+          where: { id: report.id },
+          data: {
+            lastRunAt: now,
+            lastGeneratedAt: now,
+            nextRunAt,
+          },
+        }),
+      ]);
+
+      details.push({ reportId: report.id, name: report.name, status: "success" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      details.push({ reportId: report.id, name: report.name, status: "error", error: message });
+    }
+  }
+
+  const executed = details.filter((d) => d.status === "success").length;
+  const errors = details.filter((d) => d.status === "error").length;
+
+  return NextResponse.json({ executed, errors, details });
+}
+
+async function generatePdfBuffer(
+  transactions: Array<{
+    date: Date;
+    type: string;
+    amount: number;
+    currency: string;
+    description: string | null;
+    category: { name: string } | null;
+    fromAccount: { name: string } | null;
+    toAccount: { name: string } | null;
+  }>,
+  summary: {
+    totalTransactions: number;
+    totalExpenses: number;
+    totalIncome: number;
+    totalTransfers: number;
+    netAmount: number;
+  },
+  reportName: string
+): Promise<Buffer> {
+  const doc = new PDFDocument({ size: "A4", margin: 40, bufferPages: true });
+  const chunks: Buffer[] = [];
+
+  doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+  doc.fontSize(20).font("Helvetica-Bold").text(reportName, { align: "center" });
+  doc.moveDown(0.3);
+  doc
+    .fontSize(10)
+    .font("Helvetica")
+    .fillColor("#666666")
+    .text(
+      `Generated ${new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}`,
+      { align: "center" }
+    );
+  doc.moveDown(1);
+
+  doc.fillColor("#000000").fontSize(14).font("Helvetica-Bold").text("Summary");
+  doc.moveDown(0.4);
+  doc.fontSize(10).font("Helvetica").fillColor("#333333");
+
+  const summaryItems = [
+    ["Total Transactions", summary.totalTransactions.toString()],
+    ["Total Income", `+${summary.totalIncome.toFixed(2)}`],
+    ["Total Expenses", `-${summary.totalExpenses.toFixed(2)}`],
+    ["Total Transfers", summary.totalTransfers.toFixed(2)],
+    ["Net Amount", summary.netAmount.toFixed(2)],
+  ];
+
+  for (const [label, value] of summaryItems) {
+    doc.font("Helvetica").text(`${label}: `, { continued: true });
+    doc.font("Helvetica-Bold").text(value);
+  }
+
+  doc.moveDown(1);
+  doc.fillColor("#000000").fontSize(14).font("Helvetica-Bold").text("Transactions");
+  doc.moveDown(0.5);
+
+  if (transactions.length === 0) {
+    doc.fontSize(10).font("Helvetica").fillColor("#666666").text("No transactions found.");
+  } else {
+    const colWidths = [70, 55, 80, 200, 110];
+    const colHeaders = ["Date", "Type", "Amount", "Description", "Category"];
+    const tableLeft = 40;
+    const rowHeight = 18;
+
+    let y = doc.y;
+    doc.fontSize(8).font("Helvetica-Bold").fillColor("#444444");
+    doc.save();
+    doc.rect(tableLeft, y - 2, colWidths.reduce((a, b) => a + b, 0), rowHeight).fill("#f0f0f0");
+    doc.restore();
+
+    doc.fillColor("#444444");
+    let x = tableLeft;
+    for (let i = 0; i < colHeaders.length; i++) {
+      doc.text(colHeaders[i], x, y, { width: colWidths[i], align: i === 2 ? "right" : "left" });
+      x += colWidths[i];
+    }
+    y += rowHeight;
+
+    doc.font("Helvetica").fontSize(8).fillColor("#333333");
+
+    for (const txn of transactions) {
+      if (y + rowHeight > doc.page.height - 50) {
+        doc.addPage();
+        y = 40;
+        doc.save();
+        doc.rect(tableLeft, y - 2, colWidths.reduce((a, b) => a + b, 0), rowHeight).fill("#f0f0f0");
+        doc.restore();
+        doc.font("Helvetica-Bold").fontSize(8).fillColor("#444444");
+        x = tableLeft;
+        for (let i = 0; i < colHeaders.length; i++) {
+          doc.text(colHeaders[i], x, y, { width: colWidths[i], align: i === 2 ? "right" : "left" });
+          x += colWidths[i];
+        }
+        y += rowHeight;
+        doc.font("Helvetica").fontSize(8).fillColor("#333333");
+      }
+
+      if (transactions.indexOf(txn) % 2 === 1) {
+        doc.save();
+        doc.rect(tableLeft, y - 2, colWidths.reduce((a, b) => a + b, 0), rowHeight).fill("#fafafa");
+        doc.restore();
+        doc.fillColor("#333333");
+      }
+
+      x = tableLeft;
+      const date = new Date(txn.date).toISOString().split("T")[0];
+      const desc = txn.description || "—";
+      const cat = txn.category?.name || "—";
+      const amt = `${txn.amount.toFixed(2)} ${txn.currency}`;
+
+      doc.text(date, x, y, { width: colWidths[0] });
+      x += colWidths[0];
+      doc.text(txn.type, x, y, { width: colWidths[1] });
+      x += colWidths[1];
+      doc.text(amt, x, y, { width: colWidths[2], align: "right" });
+      x += colWidths[2];
+      doc.text(desc.substring(0, 40), x, y, { width: colWidths[3] });
+      x += colWidths[3];
+      doc.text(cat.substring(0, 20), x, y, { width: colWidths[4] });
+      y += rowHeight;
+    }
+  }
+
+  const pageCount = doc.bufferedPageRange().count;
+  for (let i = 0; i < pageCount; i++) {
+    doc.switchToPage(i);
+    doc
+      .fontSize(8)
+      .font("Helvetica")
+      .fillColor("#aaaaaa")
+      .text(`Page ${i + 1} of ${pageCount}`, 40, doc.page.height - 30, {
+        align: "center",
+        width: doc.page.width - 80,
+      });
+  }
+
+  return new Promise<Buffer>((resolve) => {
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    doc.end();
+  });
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { calculateNextRunAt } from "@/lib/report-schedule";
 
 // GET /api/reports — list user's saved reports
 export async function GET() {
@@ -12,12 +13,19 @@ export async function GET() {
   const reports = await db.savedReport.findMany({
     where: { userId: user.id },
     orderBy: { updatedAt: "desc" },
+    include: {
+      _count: {
+        select: { generatedReports: true },
+      },
+    },
   });
 
   return NextResponse.json(
     reports.map((r) => ({
       ...r,
       filters: JSON.parse(r.filters),
+      generatedCount: r._count.generatedReports,
+      _count: undefined,
     }))
   );
 }
@@ -30,7 +38,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { name, description, format, filters } = body;
+  const { name, description, format, filters, scheduleEnabled, scheduleFrequency, scheduleDay, scheduleTime } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {
     return NextResponse.json(
@@ -49,6 +57,12 @@ export async function POST(request: NextRequest) {
   const validFormats = ["csv", "json", "pdf"];
   const reportFormat = validFormats.includes(format) ? format : "csv";
 
+  // Calculate nextRunAt if schedule is enabled
+  let nextRunAt: Date | null = null;
+  if (scheduleEnabled && scheduleFrequency) {
+    nextRunAt = calculateNextRunAt(scheduleFrequency, scheduleDay ?? null);
+  }
+
   const report = await db.savedReport.create({
     data: {
       userId: user.id,
@@ -56,6 +70,11 @@ export async function POST(request: NextRequest) {
       description: description?.trim() || null,
       format: reportFormat,
       filters: JSON.stringify(filters),
+      scheduleEnabled: !!scheduleEnabled,
+      scheduleFrequency: scheduleEnabled ? scheduleFrequency || null : null,
+      scheduleDay: scheduleEnabled ? (scheduleDay ?? null) : null,
+      scheduleTime: scheduleEnabled ? (scheduleTime || null) : null,
+      nextRunAt,
     },
   });
 

--- a/src/components/reports-manager.tsx
+++ b/src/components/reports-manager.tsx
@@ -31,6 +31,28 @@ interface SavedReport {
   lastRunAt: string | null;
   createdAt: string;
   updatedAt: string;
+  scheduleEnabled: boolean;
+  scheduleFrequency: string | null;
+  scheduleDay: number | null;
+  scheduleTime: string | null;
+  nextRunAt: string | null;
+  lastGeneratedAt: string | null;
+  generatedCount: number;
+}
+
+interface GeneratedReport {
+  id: string;
+  format: string;
+  fileName: string | null;
+  summary: {
+    totalTransactions: number;
+    totalExpenses: number;
+    totalIncome: number;
+    totalTransfers: number;
+    netAmount: number;
+  } | null;
+  generatedAt: string;
+  expiresAt: string | null;
 }
 
 interface JsonReportResult {
@@ -83,6 +105,14 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
   const [formAccountId, setFormAccountId] = useState("");
   const [formCategoryId, setFormCategoryId] = useState("");
   const [formPeriodPreset, setFormPeriodPreset] = useState("");
+  const [formScheduleEnabled, setFormScheduleEnabled] = useState(false);
+  const [formScheduleFrequency, setFormScheduleFrequency] = useState("weekly");
+  const [formScheduleDay, setFormScheduleDay] = useState<number | null>(1);
+
+  // Generated reports state
+  const [viewingGenerated, setViewingGenerated] = useState<string | null>(null);
+  const [generatedReports, setGeneratedReports] = useState<GeneratedReport[]>([]);
+  const [loadingGenerated, setLoadingGenerated] = useState(false);
 
   const fetchReports = useCallback(async () => {
     try {
@@ -110,6 +140,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
     setFormAccountId("");
     setFormCategoryId("");
     setFormPeriodPreset("");
+    setFormScheduleEnabled(false);
+    setFormScheduleFrequency("weekly");
+    setFormScheduleDay(1);
   }
 
   function populateForm(report: SavedReport) {
@@ -120,6 +153,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
     setFormAccountId(report.filters.accountId || "");
     setFormCategoryId(report.filters.categoryId || "");
     setFormPeriodPreset(report.filters.periodPreset || "");
+    setFormScheduleEnabled(report.scheduleEnabled);
+    setFormScheduleFrequency(report.scheduleFrequency || "weekly");
+    setFormScheduleDay(report.scheduleDay);
   }
 
   function buildFilters(): ReportFilters {
@@ -149,6 +185,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
           description: formDescription.trim() || undefined,
           format: formFormat,
           filters: buildFilters(),
+          scheduleEnabled: formScheduleEnabled,
+          scheduleFrequency: formScheduleEnabled ? formScheduleFrequency : undefined,
+          scheduleDay: formScheduleEnabled ? formScheduleDay : undefined,
         }),
       });
 
@@ -185,6 +224,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
           description: formDescription.trim() || null,
           format: formFormat,
           filters: buildFilters(),
+          scheduleEnabled: formScheduleEnabled,
+          scheduleFrequency: formScheduleEnabled ? formScheduleFrequency : undefined,
+          scheduleDay: formScheduleEnabled ? formScheduleDay : undefined,
         }),
       });
 
@@ -326,6 +368,68 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
     });
   }
 
+  function formatSchedule(report: SavedReport): string {
+    if (!report.scheduleEnabled || !report.scheduleFrequency) return "";
+    const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    switch (report.scheduleFrequency) {
+      case "daily":
+        return "Daily";
+      case "weekly":
+        return report.scheduleDay !== null
+          ? `Weekly on ${dayNames[report.scheduleDay]}`
+          : "Weekly";
+      case "monthly": {
+        if (report.scheduleDay !== null) {
+          const s = ["th", "st", "nd", "rd"];
+          const v = report.scheduleDay % 100;
+          const suffix = s[(v - 20) % 10] || s[v] || s[0];
+          return `Monthly on the ${report.scheduleDay}${suffix}`;
+        }
+        return "Monthly";
+      }
+      default:
+        return report.scheduleFrequency;
+    }
+  }
+
+  async function loadGeneratedReports(reportId: string) {
+    if (viewingGenerated === reportId) {
+      setViewingGenerated(null);
+      return;
+    }
+    setViewingGenerated(reportId);
+    setLoadingGenerated(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/generated`);
+      if (res.ok) {
+        const data = await res.json();
+        setGeneratedReports(data);
+      }
+    } catch {
+      console.error("Failed to load generated reports");
+    } finally {
+      setLoadingGenerated(false);
+    }
+  }
+
+  async function downloadGeneratedReport(reportId: string, genId: string, fileName: string | null, format: string) {
+    try {
+      const res = await fetch(`/api/reports/${reportId}/generated/${genId}`);
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fileName || `report.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      console.error("Failed to download generated report");
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
@@ -402,6 +506,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
             accountId={formAccountId}
             categoryId={formCategoryId}
             periodPreset={formPeriodPreset}
+            scheduleEnabled={formScheduleEnabled}
+            scheduleFrequency={formScheduleFrequency}
+            scheduleDay={formScheduleDay}
             accounts={accounts}
             categories={categories}
             onNameChange={setFormName}
@@ -411,6 +518,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
             onAccountIdChange={setFormAccountId}
             onCategoryIdChange={setFormCategoryId}
             onPeriodPresetChange={setFormPeriodPreset}
+            onScheduleEnabledChange={setFormScheduleEnabled}
+            onScheduleFrequencyChange={setFormScheduleFrequency}
+            onScheduleDayChange={setFormScheduleDay}
             onSubmit={handleCreate}
             onCancel={() => {
               setShowCreate(false);
@@ -436,6 +546,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
             accountId={formAccountId}
             categoryId={formCategoryId}
             periodPreset={formPeriodPreset}
+            scheduleEnabled={formScheduleEnabled}
+            scheduleFrequency={formScheduleFrequency}
+            scheduleDay={formScheduleDay}
             accounts={accounts}
             categories={categories}
             onNameChange={setFormName}
@@ -445,6 +558,9 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
             onAccountIdChange={setFormAccountId}
             onCategoryIdChange={setFormCategoryId}
             onPeriodPresetChange={setFormPeriodPreset}
+            onScheduleEnabledChange={setFormScheduleEnabled}
+            onScheduleFrequencyChange={setFormScheduleFrequency}
+            onScheduleDayChange={setFormScheduleDay}
             onSubmit={handleUpdate}
             onCancel={cancelEdit}
             submitLabel="Save Changes"
@@ -522,9 +638,32 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
                   <p className="text-xs text-gray-400 dark:text-gray-500">
                     {formatFilterSummary(report.filters)}
                   </p>
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                    Last run: {formatDate(report.lastRunAt)}
-                  </p>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1">
+                    <p className="text-xs text-gray-400 dark:text-gray-500">
+                      Last run: {formatDate(report.lastRunAt)}
+                    </p>
+                    {report.scheduleEnabled && (
+                      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        </svg>
+                        {formatSchedule(report)}
+                        {report.nextRunAt && (
+                          <span className="text-gray-400 dark:text-gray-500">
+                            · Next: {formatDate(report.nextRunAt)}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    {report.generatedCount > 0 && (
+                      <button
+                        onClick={() => loadGeneratedReports(report.id)}
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        {viewingGenerated === report.id ? "Hide" : "View"} history ({report.generatedCount})
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 <div className="flex items-center gap-1.5 shrink-0">
@@ -601,6 +740,58 @@ export function ReportsManager({ accounts, categories }: ReportsManagerProps) {
                   </button>
                 </div>
               </div>
+
+              {/* Generated reports history */}
+              {viewingGenerated === report.id && (
+                <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800">
+                  <h4 className="text-xs font-semibold text-gray-600 dark:text-gray-400 mb-2 uppercase tracking-wider">
+                    Generated Reports
+                  </h4>
+                  {loadingGenerated ? (
+                    <div className="flex items-center gap-2 py-2">
+                      <div className="w-3 h-3 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin" />
+                      <span className="text-xs text-gray-400">Loading...</span>
+                    </div>
+                  ) : generatedReports.length === 0 ? (
+                    <p className="text-xs text-gray-400 py-2">No generated reports yet.</p>
+                  ) : (
+                    <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                      {generatedReports.map((gen) => (
+                        <div
+                          key={gen.id}
+                          className="flex items-center justify-between gap-2 py-1.5 px-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                        >
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 uppercase">
+                              {gen.format}
+                            </span>
+                            <span className="text-xs text-gray-600 dark:text-gray-300 truncate">
+                              {gen.fileName || `report.${gen.format}`}
+                            </span>
+                            <span className="text-[10px] text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                              {formatDate(gen.generatedAt)}
+                            </span>
+                            {gen.summary && (
+                              <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                                ({gen.summary.totalTransactions} txns)
+                              </span>
+                            )}
+                          </div>
+                          <button
+                            onClick={() => downloadGeneratedReport(report.id, gen.id, gen.fileName, gen.format)}
+                            className="shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
+                          >
+                            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                            </svg>
+                            Download
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -762,6 +953,8 @@ function SummaryCard({
   );
 }
 
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
 function ReportForm({
   name,
   description,
@@ -770,6 +963,9 @@ function ReportForm({
   accountId,
   categoryId,
   periodPreset,
+  scheduleEnabled,
+  scheduleFrequency,
+  scheduleDay,
   accounts,
   categories,
   onNameChange,
@@ -779,6 +975,9 @@ function ReportForm({
   onAccountIdChange,
   onCategoryIdChange,
   onPeriodPresetChange,
+  onScheduleEnabledChange,
+  onScheduleFrequencyChange,
+  onScheduleDayChange,
   onSubmit,
   onCancel,
   submitLabel,
@@ -790,6 +989,9 @@ function ReportForm({
   accountId: string;
   categoryId: string;
   periodPreset: string;
+  scheduleEnabled: boolean;
+  scheduleFrequency: string;
+  scheduleDay: number | null;
   accounts: Account[];
   categories: Category[];
   onNameChange: (v: string) => void;
@@ -799,6 +1001,9 @@ function ReportForm({
   onAccountIdChange: (v: string) => void;
   onCategoryIdChange: (v: string) => void;
   onPeriodPresetChange: (v: string) => void;
+  onScheduleEnabledChange: (v: boolean) => void;
+  onScheduleFrequencyChange: (v: string) => void;
+  onScheduleDayChange: (v: number | null) => void;
   onSubmit: (e: React.FormEvent) => void;
   onCancel: () => void;
   submitLabel: string;
@@ -921,6 +1126,86 @@ function ReportForm({
             </select>
           </div>
         </div>
+      </div>
+
+      {/* Schedule section */}
+      <div>
+        <div className="flex items-center gap-3 mb-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={scheduleEnabled}
+              onChange={(e) => onScheduleEnabledChange(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-emerald-600 focus:ring-emerald-500"
+            />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Auto-generate on schedule
+            </span>
+          </label>
+        </div>
+
+        {scheduleEnabled && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 pl-6">
+            <div>
+              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                Frequency
+              </label>
+              <select
+                value={scheduleFrequency}
+                onChange={(e) => {
+                  onScheduleFrequencyChange(e.target.value);
+                  // Reset day when frequency changes
+                  if (e.target.value === "daily") onScheduleDayChange(null);
+                  else if (e.target.value === "weekly") onScheduleDayChange(1);
+                  else if (e.target.value === "monthly") onScheduleDayChange(1);
+                }}
+                className={inputClass}
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+            </div>
+
+            {scheduleFrequency === "weekly" && (
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Day of week
+                </label>
+                <select
+                  value={scheduleDay ?? 1}
+                  onChange={(e) => onScheduleDayChange(parseInt(e.target.value))}
+                  className={inputClass}
+                >
+                  {DAY_NAMES.map((d, i) => (
+                    <option key={i} value={i}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {scheduleFrequency === "monthly" && (
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  Day of month
+                </label>
+                <select
+                  value={scheduleDay ?? 1}
+                  onChange={(e) => onScheduleDayChange(parseInt(e.target.value))}
+                  className={inputClass}
+                >
+                  {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
+                    <option key={d} value={d}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex items-center gap-2 pt-2">

--- a/src/lib/report-schedule.ts
+++ b/src/lib/report-schedule.ts
@@ -1,0 +1,82 @@
+/**
+ * Calculate the next scheduled run date for a report based on frequency and day.
+ */
+export function calculateNextRunAt(
+  frequency: string,
+  day: number | null,
+  from?: Date
+): Date {
+  const base = from ?? new Date();
+  const next = new Date(base);
+
+  switch (frequency) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "weekly": {
+      // day = 0-6 (Sun-Sat)
+      const targetDay = day ?? 1; // default Monday
+      const currentDay = next.getDay();
+      let daysUntil = targetDay - currentDay;
+      if (daysUntil <= 0) daysUntil += 7;
+      next.setDate(next.getDate() + daysUntil);
+      break;
+    }
+    case "monthly": {
+      // day = 1-31
+      const targetDom = day ?? 1;
+      next.setMonth(next.getMonth() + 1);
+      const maxDay = new Date(
+        next.getFullYear(),
+        next.getMonth() + 1,
+        0
+      ).getDate();
+      next.setDate(Math.min(targetDom, maxDay));
+      break;
+    }
+    default:
+      next.setDate(next.getDate() + 1);
+  }
+
+  // Set to midnight UTC
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+/**
+ * Format a report schedule for display.
+ */
+export function formatReportSchedule(
+  frequency: string,
+  day: number | null
+): string {
+  const dayNames = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+
+  switch (frequency) {
+    case "daily":
+      return "Every day";
+    case "weekly":
+      return day !== null && day >= 0 && day <= 6
+        ? `Every ${dayNames[day]}`
+        : "Every week";
+    case "monthly": {
+      if (day !== null && day >= 1 && day <= 31) {
+        const s = ["th", "st", "nd", "rd"];
+        const v = day % 100;
+        const suffix = s[(v - 20) % 10] || s[v] || s[0];
+        return `Monthly on the ${day}${suffix}`;
+      }
+      return "Every month";
+    }
+    default:
+      return frequency;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds auto-generation support for saved reports on configurable schedules (daily, weekly, monthly)
- Generated reports are stored in the database with 30-day retention and downloadable from report history
- New `GeneratedReport` model stores binary file data (CSV/PDF/JSON) alongside metadata

## Changes
- **Schema**: Added scheduling fields to `SavedReport` (scheduleEnabled, scheduleFrequency, scheduleDay, nextRunAt, lastGeneratedAt) and new `GeneratedReport` model
- **API**: `POST /api/reports/execute-scheduled` finds and executes all due reports, stores results, advances schedule. `GET/DELETE /api/reports/[id]/generated/[genId]` for history management
- **UI**: Schedule toggle with frequency/day configuration in report form. Schedule indicator on report cards. Expandable generated report history with download links

## Test plan
- [ ] Create a report with schedule enabled (weekly, Monday) — verify nextRunAt is set
- [ ] Call execute-scheduled endpoint — verify report generates and nextRunAt advances
- [ ] View generated report history — verify download works for CSV/PDF/JSON
- [ ] Edit report to disable schedule — verify nextRunAt is cleared
- [ ] Create report without schedule — verify no schedule fields are set

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)