### PR TITLE
feat: add error boundaries, loading states, and 404 page

### DIFF
--- a/src/app/accounts/error.tsx
+++ b/src/app/accounts/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function AccountsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load accounts"
+      description="We couldn't load your accounts. This might be a temporary issue."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/accounts/loading.tsx
+++ b/src/app/accounts/loading.tsx
@@ -1,0 +1,16 @@
+export default function AccountsLoading() {
+  return (
+    <main className="flex-1 w-full max-w-5xl mx-auto px-4 py-8 animate-pulse">
+      <div className="h-4 w-24 bg-gray-200 dark:bg-gray-800 rounded mb-4" />
+      <div className="h-8 w-36 bg-gray-200 dark:bg-gray-800 rounded mb-6" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-5 h-28"
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/analytics/error.tsx
+++ b/src/app/analytics/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function AnalyticsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load analytics"
+      description="We couldn't generate your analytics. This might be a temporary issue with data processing."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/analytics/loading.tsx
+++ b/src/app/analytics/loading.tsx
@@ -1,0 +1,20 @@
+export default function AnalyticsLoading() {
+  return (
+    <main className="flex-1 w-full max-w-5xl mx-auto px-4 py-8 animate-pulse">
+      <div className="h-4 w-24 bg-gray-200 dark:bg-gray-800 rounded mb-4" />
+      <div className="h-8 w-36 bg-gray-200 dark:bg-gray-800 rounded mb-6" />
+      <div className="space-y-6">
+        {/* Chart skeletons */}
+        {[1, 2].map((i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6"
+          >
+            <div className="h-5 w-48 bg-gray-200 dark:bg-gray-800 rounded mb-4" />
+            <div className="h-64 bg-gray-100 dark:bg-gray-800 rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Page error:", error);
+  }, [error]);
+
+  return (
+    <main className="flex-1 flex items-center justify-center px-4 py-16">
+      <div className="max-w-md w-full text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 mb-6">
+          <svg
+            className="w-8 h-8 text-red-600 dark:text-red-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+            />
+          </svg>
+        </div>
+
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          Something went wrong
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          An unexpected error occurred. You can try again or go back to the
+          dashboard.
+        </p>
+
+        {error.digest && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-4 font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="px-5 py-2.5 rounded-xl bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition-colors text-sm"
+          >
+            Try again
+          </button>
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Full reload to clear broken state */}
+          <a
+            href="/"
+            className="px-5 py-2.5 rounded-xl border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-sm"
+          >
+            Go to Dashboard
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-950 px-4">
+        <div className="max-w-md w-full text-center">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 mb-6">
+            <svg
+              className="w-8 h-8 text-red-600 dark:text-red-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+
+          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            Application Error
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400 mb-6">
+            A critical error occurred. Please try refreshing the page.
+          </p>
+
+          {error.digest && (
+            <p className="text-xs text-gray-400 dark:text-gray-500 mb-4 font-mono">
+              Error ID: {error.digest}
+            </p>
+          )}
+
+          <div className="flex items-center justify-center gap-3">
+            <button
+              onClick={reset}
+              className="px-5 py-2.5 rounded-xl bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition-colors text-sm"
+            >
+              Try again
+            </button>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Full reload to clear broken state */}
+            <a
+              href="/"
+              className="px-5 py-2.5 rounded-xl border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-sm"
+            >
+              Reload
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/insights/error.tsx
+++ b/src/app/insights/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function InsightsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load insights"
+      description="We couldn't generate your financial insights. The AI service might be temporarily unavailable."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,40 @@
+export default function Loading() {
+  return (
+    <main className="flex-1 px-4 py-8">
+      <div className="max-w-5xl mx-auto space-y-8 animate-pulse">
+        {/* Title skeleton */}
+        <div className="h-8 w-40 bg-gray-200 dark:bg-gray-800 rounded-lg" />
+
+        {/* Balance card skeleton */}
+        <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-6">
+          <div className="h-4 w-24 bg-gray-200 dark:bg-gray-800 rounded mb-3" />
+          <div className="h-10 w-48 bg-gray-200 dark:bg-gray-800 rounded" />
+        </div>
+
+        {/* Grid skeleton */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 h-20"
+            />
+          ))}
+        </div>
+
+        {/* List skeleton */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex items-center gap-3 px-4 py-3">
+              <div className="w-8 h-8 rounded-lg bg-gray-200 dark:bg-gray-800" />
+              <div className="flex-1">
+                <div className="h-4 w-32 bg-gray-200 dark:bg-gray-800 rounded mb-1" />
+                <div className="h-3 w-20 bg-gray-100 dark:bg-gray-800 rounded" />
+              </div>
+              <div className="h-4 w-16 bg-gray-200 dark:bg-gray-800 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex-1 flex items-center justify-center px-4 py-16">
+      <div className="max-w-md w-full text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800 mb-6">
+          <span className="text-3xl">404</span>
+        </div>
+
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          Page not found
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition-colors text-sm"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+            />
+          </svg>
+          Back to Dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/receipts/error.tsx
+++ b/src/app/receipts/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function ReceiptsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load receipts"
+      description="We couldn't load your receipts. Please try again."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/reports/error.tsx
+++ b/src/app/reports/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function ReportsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load reports"
+      description="We couldn't load your reports. Please try again."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/spaces/error.tsx
+++ b/src/app/spaces/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function SpacesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load spaces"
+      description="We couldn't load your shared spaces. Please try again."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/transactions/error.tsx
+++ b/src/app/transactions/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SectionError } from "@/components/section-error";
+
+export default function TransactionsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <SectionError
+      title="Failed to load transactions"
+      description="We couldn't load your transactions. Please try again."
+      error={error}
+      reset={reset}
+      backHref="/"
+      backLabel="Dashboard"
+    />
+  );
+}

--- a/src/app/transactions/loading.tsx
+++ b/src/app/transactions/loading.tsx
@@ -1,0 +1,31 @@
+export default function TransactionsLoading() {
+  return (
+    <main className="flex-1 w-full max-w-5xl mx-auto px-4 py-8 animate-pulse">
+      {/* Breadcrumb */}
+      <div className="h-4 w-24 bg-gray-200 dark:bg-gray-800 rounded mb-4" />
+      {/* Title */}
+      <div className="h-8 w-48 bg-gray-200 dark:bg-gray-800 rounded mb-6" />
+      {/* Filters */}
+      <div className="flex gap-3 mb-6">
+        <div className="h-10 w-32 bg-gray-200 dark:bg-gray-800 rounded-lg" />
+        <div className="h-10 w-32 bg-gray-200 dark:bg-gray-800 rounded-lg" />
+      </div>
+      {/* List */}
+      <div className="space-y-2">
+        {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 px-4 py-3"
+          >
+            <div className="w-8 h-8 rounded-lg bg-gray-200 dark:bg-gray-800" />
+            <div className="flex-1">
+              <div className="h-4 w-40 bg-gray-200 dark:bg-gray-800 rounded mb-1" />
+              <div className="h-3 w-24 bg-gray-100 dark:bg-gray-800 rounded" />
+            </div>
+            <div className="h-4 w-20 bg-gray-200 dark:bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/components/section-error.tsx
+++ b/src/components/section-error.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface SectionErrorProps {
+  title: string;
+  description: string;
+  error: Error & { digest?: string };
+  reset: () => void;
+  backHref: string;
+  backLabel: string;
+}
+
+export function SectionError({
+  title,
+  description,
+  error,
+  reset,
+  backHref,
+  backLabel,
+}: SectionErrorProps) {
+  useEffect(() => {
+    console.error("Section error:", error);
+  }, [error]);
+
+  return (
+    <main className="flex-1 px-4 py-8">
+      <div className="max-w-xl mx-auto">
+        <div className="rounded-xl border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30 p-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-100 dark:bg-red-900/40 mb-4">
+            <svg
+              className="w-6 h-6 text-red-600 dark:text-red-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+
+          <h2 className="text-lg font-semibold text-red-900 dark:text-red-200 mb-1">
+            {title}
+          </h2>
+          <p className="text-sm text-red-700 dark:text-red-300 mb-4">
+            {description}
+          </p>
+
+          {error.digest && (
+            <p className="text-xs text-red-500 dark:text-red-400 mb-4 font-mono">
+              Error ID: {error.digest}
+            </p>
+          )}
+
+          <div className="flex items-center justify-center gap-3">
+            <button
+              onClick={reset}
+              className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
+            >
+              Try again
+            </button>
+            <a
+              href={backHref}
+              className="px-4 py-2 rounded-lg border border-red-300 dark:border-red-800 text-red-700 dark:text-red-300 text-sm font-medium hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
+            >
+              {backLabel}
+            </a>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #113

- **Error boundaries**: Root `error.tsx` and `global-error.tsx` catch render errors gracefully with retry and dashboard navigation. Section-specific error pages for accounts, transactions, analytics, receipts, insights, reports, and spaces provide contextual error messages.
- **Loading states**: Skeleton UIs for dashboard, transactions, accounts, and analytics pages show animated placeholders while server components load.
- **404 page**: Custom `not-found.tsx` with a clean design and navigation back to dashboard.
- **Reusable `SectionError` component**: Shared error UI with configurable title, description, retry, and back navigation.

## Files added (15)
- `src/app/error.tsx` — root error boundary
- `src/app/global-error.tsx` — catches root layout errors
- `src/app/not-found.tsx` — custom 404
- `src/app/loading.tsx` — dashboard skeleton
- `src/app/{accounts,transactions,analytics}/loading.tsx` — section skeletons
- `src/app/{accounts,transactions,analytics,receipts,insights,reports,spaces}/error.tsx` — section error pages
- `src/components/section-error.tsx` — reusable error UI component

## Test plan
- [ ] Navigate to a non-existent route — should show custom 404 page
- [ ] Verify loading skeletons appear on slow connections (throttle network)
- [ ] Error boundaries can be tested by temporarily throwing in a server component

🤖 Generated with [Claude Code](https://claude.com/claude-code)