### PR TITLE
feat: add Vitest testing infrastructure with 97 unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,12 +29,14 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/web-push": "^3.6.4",
+        "@vitejs/plugin-react": "^6.0.1",
         "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "prisma": "^6.19.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1311,6 +1313,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
@@ -1590,6 +1602,285 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1926,6 +2217,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1987,6 +2289,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2628,6 +2937,145 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2906,6 +3354,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -3200,6 +3658,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3846,6 +4314,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4359,6 +4834,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4383,6 +4868,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -4569,6 +5064,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6359,6 +6869,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -6931,6 +7452,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7258,6 +7820,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7271,6 +7840,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7516,6 +8099,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -7572,6 +8162,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7943,6 +8543,192 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -8081,6 +8867,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
@@ -30,11 +32,13 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/web-push": "^3.6.4",
+    "@vitejs/plugin-react": "^6.0.1",
     "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "prisma": "^6.19.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/lib/__tests__/category-normalize.test.ts
+++ b/src/lib/__tests__/category-normalize.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { normalizeName, findSimilar } from "../category-normalize";
+
+describe("normalizeName", () => {
+  it("converts to title case", () => {
+    expect(normalizeName("food and dining")).toBe("Food and Dining");
+  });
+
+  it("keeps lowercase prepositions/conjunctions", () => {
+    expect(normalizeName("BILLS AND UTILITIES")).toBe("Bills and Utilities");
+  });
+
+  it("capitalizes first word even if it is a preposition", () => {
+    expect(normalizeName("the arts")).toBe("The Arts");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeName("  shopping  ")).toBe("Shopping");
+  });
+
+  it("normalizes multiple spaces", () => {
+    expect(normalizeName("food   and   dining")).toBe("Food and Dining");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeName("")).toBe("");
+    expect(normalizeName("   ")).toBe("");
+  });
+
+  it("handles single word", () => {
+    expect(normalizeName("transport")).toBe("Transport");
+  });
+
+  it("preserves & symbol", () => {
+    expect(normalizeName("food & dining")).toBe("Food & Dining");
+  });
+
+  it("handles all-caps input", () => {
+    expect(normalizeName("HEALTH")).toBe("Health");
+  });
+});
+
+describe("findSimilar", () => {
+  const existingCategories = [
+    { id: "1", name: "Food & Dining" },
+    { id: "2", name: "Transport" },
+    { id: "3", name: "Shopping" },
+    { id: "4", name: "Entertainment" },
+    { id: "5", name: "Bills & Utilities" },
+    { id: "6", name: "Health" },
+    { id: "7", name: "Education" },
+    { id: "8", name: "Salary" },
+    { id: "9", name: "Investment" },
+  ];
+
+  it("finds exact match (case-insensitive)", () => {
+    const result = findSimilar("food & dining", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("1");
+    expect(result!.score).toBe(1.0);
+  });
+
+  it("finds alias match for groceries → Food & Dining", () => {
+    const result = findSimilar("groceries", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("1");
+    expect(result!.name).toBe("Food & Dining");
+    expect(result!.score).toBe(0.95);
+  });
+
+  it("finds alias match for taxi → Transport", () => {
+    const result = findSimilar("taxi", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Transport");
+  });
+
+  it("finds alias match for netflix → Entertainment", () => {
+    const result = findSimilar("netflix", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Entertainment");
+  });
+
+  it("finds alias match for rent → Bills & Utilities", () => {
+    const result = findSimilar("rent", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Bills & Utilities");
+  });
+
+  it("finds alias match for gym → Health", () => {
+    const result = findSimilar("gym", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Health");
+  });
+
+  it("finds alias match for wages → Salary", () => {
+    const result = findSimilar("wages", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Salary");
+  });
+
+  it("finds fuzzy match for similar names", () => {
+    const result = findSimilar("Transportt", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Transport");
+    expect(result!.score).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it("returns null for empty input", () => {
+    expect(findSimilar("", existingCategories)).toBeNull();
+    expect(findSimilar("   ", existingCategories)).toBeNull();
+  });
+
+  it("returns null for completely unrelated input", () => {
+    const result = findSimilar("xyzabcdef", existingCategories);
+    // Should be null since no match above threshold
+    expect(result === null || result.score < 0.7).toBe(true);
+  });
+
+  it("returns null for empty category list", () => {
+    const result = findSimilar("Food", []);
+    expect(result).toBeNull();
+  });
+
+  it("handles substring containment (0.85 score)", () => {
+    // "Transport" contains "Trans" — similarity should catch this
+    const result = findSimilar("Transpo", existingCategories);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Transport");
+  });
+});

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { formatMoney, accountTypeLabel, accountTypeIcon } from "../format";
+
+describe("formatMoney", () => {
+  it("formats USD amounts correctly", () => {
+    expect(formatMoney(25.5, "USD")).toBe("$25.50");
+  });
+
+  it("formats EUR amounts correctly", () => {
+    expect(formatMoney(100, "EUR")).toBe("€100.00");
+  });
+
+  it("formats GBP amounts correctly", () => {
+    expect(formatMoney(49.99, "GBP")).toBe("£49.99");
+  });
+
+  it("formats zero amount", () => {
+    expect(formatMoney(0, "USD")).toBe("$0.00");
+  });
+
+  it("formats negative amount", () => {
+    expect(formatMoney(-15.5, "USD")).toBe("-$15.50");
+  });
+
+  it("formats large amounts with commas", () => {
+    const result = formatMoney(1234567.89, "USD");
+    expect(result).toBe("$1,234,567.89");
+  });
+
+  it("rounds to 2 decimal places", () => {
+    expect(formatMoney(10.999, "USD")).toBe("$11.00");
+  });
+
+  it("falls back for unknown currency codes", () => {
+    const result = formatMoney(50, "XYZ");
+    // Intl may use non-breaking space (U+00A0) — normalize for comparison
+    expect(result.replace(/\u00A0/g, " ")).toBe("XYZ 50.00");
+  });
+});
+
+describe("accountTypeLabel", () => {
+  it("returns label for cash", () => {
+    expect(accountTypeLabel("cash")).toBe("Cash");
+  });
+
+  it("returns label for bank", () => {
+    expect(accountTypeLabel("bank")).toBe("Bank Account");
+  });
+
+  it("returns label for wallet", () => {
+    expect(accountTypeLabel("wallet")).toBe("Wallet");
+  });
+
+  it("returns label for credit", () => {
+    expect(accountTypeLabel("credit")).toBe("Credit Card");
+  });
+
+  it("returns raw type for unknown types", () => {
+    expect(accountTypeLabel("savings")).toBe("savings");
+  });
+});
+
+describe("accountTypeIcon", () => {
+  it("returns icon for cash", () => {
+    expect(accountTypeIcon("cash")).toBe("banknotes");
+  });
+
+  it("returns icon for bank", () => {
+    expect(accountTypeIcon("bank")).toBe("building-library");
+  });
+
+  it("returns default icon for unknown types", () => {
+    expect(accountTypeIcon("unknown")).toBe("currency-dollar");
+  });
+});

--- a/src/lib/__tests__/parse-natural.test.ts
+++ b/src/lib/__tests__/parse-natural.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { parseWithRegex } from "../parse-natural";
+
+describe("parseWithRegex", () => {
+  describe("currency detection", () => {
+    it("parses $ symbol before amount", () => {
+      const result = parseWithRegex("Coffee $5.50");
+      expect(result.amount).toBe(5.5);
+      expect(result.currency).toBe("USD");
+    });
+
+    it("parses € symbol before amount", () => {
+      const result = parseWithRegex("€15.50 lunch");
+      expect(result.amount).toBe(15.5);
+      expect(result.currency).toBe("EUR");
+    });
+
+    it("parses £ symbol before amount", () => {
+      const result = parseWithRegex("£100 groceries");
+      expect(result.amount).toBe(100);
+      expect(result.currency).toBe("GBP");
+    });
+
+    it("parses currency code after amount", () => {
+      const result = parseWithRegex("25 EUR coffee");
+      expect(result.amount).toBe(25);
+      expect(result.currency).toBe("EUR");
+    });
+
+    it("parses currency code before amount", () => {
+      const result = parseWithRegex("USD 50 for groceries");
+      expect(result.amount).toBe(50);
+      expect(result.currency).toBe("USD");
+    });
+
+    it("defaults to USD when no currency specified", () => {
+      const result = parseWithRegex("Coffee 5");
+      expect(result.currency).toBe("USD");
+    });
+
+    it("handles comma as decimal separator", () => {
+      const result = parseWithRegex("$5,50 coffee");
+      expect(result.amount).toBe(5.5);
+    });
+  });
+
+  describe("transaction type detection", () => {
+    it("defaults to expense", () => {
+      const result = parseWithRegex("Coffee $5");
+      expect(result.type).toBe("expense");
+    });
+
+    it("detects income from 'earned'", () => {
+      const result = parseWithRegex("earned $500 from freelance");
+      expect(result.type).toBe("income");
+    });
+
+    it("detects income from 'salary'", () => {
+      const result = parseWithRegex("salary $3000");
+      expect(result.type).toBe("income");
+    });
+
+    it("detects income from 'received'", () => {
+      const result = parseWithRegex("received $200 payment");
+      expect(result.type).toBe("income");
+    });
+
+    it("detects transfer from 'transfer'", () => {
+      const result = parseWithRegex("transfer $100 to savings");
+      expect(result.type).toBe("transfer");
+    });
+
+    it("detects transfer from 'moved to'", () => {
+      const result = parseWithRegex("moved to savings $500");
+      expect(result.type).toBe("transfer");
+    });
+  });
+
+  describe("description extraction", () => {
+    it("extracts description removing amount and currency", () => {
+      const result = parseWithRegex("Coffee $5.50");
+      expect(result.description).toBe("Coffee");
+    });
+
+    it("removes action keywords from description", () => {
+      const result = parseWithRegex("spent $25 on lunch");
+      expect(result.description.trim()).toBeTruthy();
+    });
+
+    it("defaults to 'Expense' when description is empty", () => {
+      const result = parseWithRegex("$25");
+      expect(result.description).toBe("Expense");
+    });
+
+    it("defaults to 'Income' when income type and no description", () => {
+      const result = parseWithRegex("received $500");
+      expect(result.description).toBe("Income");
+    });
+  });
+
+  describe("amount parsing", () => {
+    it("parses integer amounts", () => {
+      const result = parseWithRegex("$100 groceries");
+      expect(result.amount).toBe(100);
+    });
+
+    it("parses decimal amounts", () => {
+      const result = parseWithRegex("$49.99 shirt");
+      expect(result.amount).toBe(49.99);
+    });
+
+    it("returns 0 when no amount found", () => {
+      const result = parseWithRegex("coffee");
+      expect(result.amount).toBe(0);
+    });
+  });
+
+  describe("various currencies", () => {
+    it("parses JPY", () => {
+      const result = parseWithRegex("1500 JPY ramen");
+      expect(result.currency).toBe("JPY");
+      expect(result.amount).toBe(1500);
+    });
+
+    it("parses CHF", () => {
+      const result = parseWithRegex("CHF 25 chocolate");
+      expect(result.currency).toBe("CHF");
+      expect(result.amount).toBe(25);
+    });
+
+    it("parses ¥ symbol", () => {
+      const result = parseWithRegex("¥1000 sushi");
+      expect(result.amount).toBe(1000);
+      expect(result.currency).toBe("JPY");
+    });
+
+    it("parses ₹ symbol", () => {
+      const result = parseWithRegex("₹500 dinner");
+      expect(result.amount).toBe(500);
+      expect(result.currency).toBe("INR");
+    });
+  });
+});

--- a/src/lib/__tests__/products.test.ts
+++ b/src/lib/__tests__/products.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { normalizeProductName } from "../products";
+
+describe("normalizeProductName", () => {
+  it("lowercases the name", () => {
+    expect(normalizeProductName("Whole Milk 2%")).toBe("whole milk 2%");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeProductName("  milk  ")).toBe("milk");
+  });
+
+  it("collapses multiple spaces", () => {
+    expect(normalizeProductName("whole   milk   2%")).toBe("whole milk 2%");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeProductName("")).toBe("");
+  });
+
+  it("handles already normalized name", () => {
+    expect(normalizeProductName("organic eggs")).toBe("organic eggs");
+  });
+
+  it("handles tabs and newlines", () => {
+    expect(normalizeProductName("brown\trice\n1kg")).toBe("brown rice 1kg");
+  });
+});

--- a/src/lib/__tests__/schedule.test.ts
+++ b/src/lib/__tests__/schedule.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { calculateNextExecution, formatFrequency } from "../schedule";
+
+describe("calculateNextExecution", () => {
+  const baseDate = new Date("2026-03-15T12:00:00Z");
+
+  describe("daily frequency", () => {
+    it("adds 1 day for interval 1", () => {
+      const result = calculateNextExecution("daily", 1, null, null, baseDate);
+      expect(result.getDate()).toBe(16);
+    });
+
+    it("adds multiple days for larger interval", () => {
+      const result = calculateNextExecution("daily", 3, null, null, baseDate);
+      expect(result.getDate()).toBe(18);
+    });
+  });
+
+  describe("weekly frequency", () => {
+    it("adds 7 days for interval 1 without dayOfWeek", () => {
+      const result = calculateNextExecution("weekly", 1, null, null, baseDate);
+      expect(result.getDate()).toBe(22);
+    });
+
+    it("adds 14 days for interval 2 without dayOfWeek", () => {
+      const result = calculateNextExecution("weekly", 2, null, null, baseDate);
+      expect(result.getDate()).toBe(29);
+    });
+
+    it("snaps to target day of week", () => {
+      // March 15 2026 is a Sunday (0)
+      // Target: Monday (1)
+      const result = calculateNextExecution("weekly", 1, 1, null, baseDate);
+      expect(result.getDay()).toBe(1); // Monday
+      expect(result > baseDate).toBe(true);
+    });
+  });
+
+  describe("monthly frequency", () => {
+    it("adds 1 month for interval 1", () => {
+      const result = calculateNextExecution("monthly", 1, null, null, baseDate);
+      expect(result.getMonth()).toBe(3); // April (0-indexed)
+    });
+
+    it("snaps to target day of month", () => {
+      const result = calculateNextExecution("monthly", 1, null, 25, baseDate);
+      expect(result.getDate()).toBe(25);
+      expect(result.getMonth()).toBe(3); // April
+    });
+
+    it("caps day at end of shorter months", () => {
+      // From Jan 15, go 1 month to February, target day 31
+      const janDate = new Date("2026-01-15T12:00:00Z");
+      const result = calculateNextExecution("monthly", 1, null, 31, janDate);
+      // Feb 2026 has 28 days
+      expect(result.getDate()).toBe(28);
+      expect(result.getMonth()).toBe(1); // February
+    });
+
+    it("adds multiple months for larger interval", () => {
+      const result = calculateNextExecution("monthly", 3, null, null, baseDate);
+      expect(result.getMonth()).toBe(5); // June
+    });
+  });
+
+  describe("unknown frequency", () => {
+    it("falls back to monthly", () => {
+      const result = calculateNextExecution("custom", 1, null, null, baseDate);
+      expect(result.getMonth()).toBe(3); // April
+    });
+  });
+});
+
+describe("formatFrequency", () => {
+  describe("interval 1", () => {
+    it("daily", () => {
+      expect(formatFrequency("daily", 1, null, null)).toBe("Every day");
+    });
+
+    it("weekly without day", () => {
+      expect(formatFrequency("weekly", 1, null, null)).toBe("Every week");
+    });
+
+    it("weekly with day", () => {
+      expect(formatFrequency("weekly", 1, 1, null)).toBe("Every Monday");
+    });
+
+    it("monthly without day", () => {
+      expect(formatFrequency("monthly", 1, null, null)).toBe("Every month");
+    });
+
+    it("monthly with day", () => {
+      expect(formatFrequency("monthly", 1, null, 15)).toBe(
+        "Monthly on the 15th"
+      );
+    });
+
+    it("monthly with 1st", () => {
+      expect(formatFrequency("monthly", 1, null, 1)).toBe(
+        "Monthly on the 1st"
+      );
+    });
+
+    it("monthly with 2nd", () => {
+      expect(formatFrequency("monthly", 1, null, 2)).toBe(
+        "Monthly on the 2nd"
+      );
+    });
+
+    it("monthly with 3rd", () => {
+      expect(formatFrequency("monthly", 1, null, 3)).toBe(
+        "Monthly on the 3rd"
+      );
+    });
+  });
+
+  describe("interval > 1", () => {
+    it("daily interval 3", () => {
+      expect(formatFrequency("daily", 3, null, null)).toBe("Every 3 days");
+    });
+
+    it("weekly interval 2", () => {
+      expect(formatFrequency("weekly", 2, null, null)).toBe("Every 2 weeks");
+    });
+
+    it("weekly interval 2 with day", () => {
+      expect(formatFrequency("weekly", 2, 5, null)).toBe(
+        "Every 2 weeks on Friday"
+      );
+    });
+
+    it("monthly interval 3", () => {
+      expect(formatFrequency("monthly", 3, null, null)).toBe(
+        "Every 3 months"
+      );
+    });
+
+    it("monthly interval 2 with day", () => {
+      expect(formatFrequency("monthly", 2, null, 10)).toBe(
+        "Every 2 months on the 10th"
+      );
+    });
+  });
+
+  describe("unknown frequency", () => {
+    it("returns generic format", () => {
+      expect(formatFrequency("custom", 2, null, null)).toBe(
+        "Every 2 custom"
+      );
+    });
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "../utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("px-4", "py-2")).toBe("px-4 py-2");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("base", false && "hidden", "visible")).toBe("base visible");
+  });
+
+  it("resolves tailwind conflicts (last wins)", () => {
+    expect(cn("px-4", "px-8")).toBe("px-8");
+  });
+
+  it("handles undefined and null values", () => {
+    expect(cn("base", undefined, null, "extra")).toBe("base extra");
+  });
+
+  it("handles empty input", () => {
+    expect(cn()).toBe("");
+  });
+
+  it("handles array input", () => {
+    expect(cn(["px-4", "py-2"])).toBe("px-4 py-2");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    exclude: ["node_modules", ".next"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Set up Vitest as the test framework with TypeScript path alias (`@/`) support
- Added `npm test` and `npm run test:watch` scripts
- Created 97 unit tests across 6 test files covering core utility functions:
  - `format.ts` — monetary formatting, account labels/icons
  - `category-normalize.ts` — name normalization, alias lookup, fuzzy matching
  - `schedule.ts` — next execution calculation, frequency formatting
  - `parse-natural.ts` — regex fallback parser (currencies, types, descriptions)
  - `products.ts` — product name normalization
  - `utils.ts` — Tailwind class merging

## Test plan
- [x] All 97 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)