### PR TITLE
fix: add safe JSON body parsing to all API routes

### DIFF
--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/accounts/[id] — get a single account
 export async function GET(
@@ -37,7 +38,8 @@ export async function PATCH(
     return NextResponse.json({ error: "Account not found" }, { status: 404 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { name, type, currency, balance, icon, color, isArchived, lowBalanceThreshold } = body;
 
   const validTypes = ["cash", "bank", "wallet", "credit"];

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
 import { getSpaceContext } from "@/lib/space-context";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/accounts — list accounts for the current context (personal or space)
 export async function GET() {
@@ -37,7 +38,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { name, type, currency, balance, icon, color, lowBalanceThreshold } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { normalizeName } from "@/lib/category-normalize";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // PATCH /api/categories/[id] — rename a category
 export async function PATCH(
@@ -10,7 +11,8 @@ export async function PATCH(
 ) {
   const user = await requireUser();
   const { id } = await params;
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const { name } = body;
   if (!name || typeof name !== "string" || !name.trim()) {

--- a/src/app/api/categories/merge/route.ts
+++ b/src/app/api/categories/merge/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categories/merge — merge source category into target
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const { sourceId, targetId } = body;
 

--- a/src/app/api/categorize/feedback/route.ts
+++ b/src/app/api/categorize/feedback/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categorize/feedback — store user correction of AI suggestion
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const { description, suggestedCategoryId, correctedCategoryId } = body;
 

--- a/src/app/api/categorize/route.ts
+++ b/src/app/api/categorize/route.ts
@@ -3,11 +3,13 @@ import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { categorizeTransaction } from "@/lib/categorize";
 import { findSimilar, normalizeName } from "@/lib/category-normalize";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categorize — AI-powered category suggestion
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const { description, amount } = body;
 

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
 import { calculateNextRunAt } from "@/lib/report-schedule";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/reports/[id] — get a single saved report
 export async function GET(
@@ -49,7 +50,8 @@ export async function PATCH(
     return NextResponse.json({ error: "Report not found" }, { status: 404 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const data: Record<string, unknown> = {};
 
   if (body.name !== undefined) {

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
 import { calculateNextRunAt } from "@/lib/report-schedule";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/reports — list user's saved reports
 export async function GET() {
@@ -37,7 +38,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { name, description, format, filters, scheduleEnabled, scheduleFrequency, scheduleDay, scheduleTime } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {

--- a/src/app/api/scheduled-transfers/[id]/route.ts
+++ b/src/app/api/scheduled-transfers/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { calculateNextExecution } from "@/lib/schedule";
+import { parseJsonBody } from "@/lib/api-utils";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -38,7 +39,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
   const { id } = await context.params;
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   // Verify ownership
   const existing = await db.scheduledTransfer.findFirst({

--- a/src/app/api/scheduled-transfers/route.ts
+++ b/src/app/api/scheduled-transfers/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { calculateNextExecution } from "@/lib/schedule";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // ─── GET /api/scheduled-transfers ───────────────────────────────────
 
@@ -35,7 +36,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const {
     fromAccountId,

--- a/src/app/api/space-context/route.ts
+++ b/src/app/api/space-context/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireApiUser } from "@/lib/auth";
 import { setSpaceContext, getSpaceContext } from "@/lib/space-context";
 import { db } from "@/lib/db";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/space-context — get current space context
 export async function GET() {
@@ -22,7 +23,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { spaceId } = body;
 
   if (spaceId) {

--- a/src/app/api/spaces/[id]/members/[memberId]/route.ts
+++ b/src/app/api/spaces/[id]/members/[memberId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 type RouteParams = { params: Promise<{ id: string; memberId: string }> };
 
@@ -38,7 +39,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: "Member not found" }, { status: 404 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { role } = body;
 
   if (!role || !["owner", "editor", "viewer"].includes(role)) {

--- a/src/app/api/spaces/[id]/members/route.ts
+++ b/src/app/api/spaces/[id]/members/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -29,7 +30,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { email, role } = body;
 
   if (!email || typeof email !== "string" || !email.includes("@")) {

--- a/src/app/api/spaces/[id]/route.ts
+++ b/src/app/api/spaces/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -70,7 +71,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { name } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { requireApiUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/spaces — list spaces the current user belongs to
 export async function GET() {
@@ -41,7 +42,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { name } = body;
 
   if (!name || typeof name !== "string" || name.trim().length === 0) {

--- a/src/app/api/transactions/parse-natural/route.ts
+++ b/src/app/api/transactions/parse-natural/route.ts
@@ -3,6 +3,7 @@ import { requireApiUser } from "@/lib/auth";
 import { parseNaturalLanguage } from "@/lib/parse-natural";
 import { categorizeTransaction } from "@/lib/categorize";
 import { db } from "@/lib/db";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/transactions/parse-natural — parse natural language into transaction fields
 export async function POST(request: NextRequest) {
@@ -11,7 +12,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
   const { text } = body;
 
   if (!text || typeof text !== "string" || text.trim().length === 0) {

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -4,6 +4,7 @@ import { requireApiUser } from "@/lib/auth";
 import { getSpaceContext, checkSpacePermission, getSpaceAccountIds } from "@/lib/space-context";
 import { checkLowBalance } from "@/lib/check-low-balance";
 import { checkUnusualSpending } from "@/lib/check-unusual-spending";
+import { parseJsonBody } from "@/lib/api-utils";
 
 // GET /api/transactions — list transactions with optional filters
 export async function GET(request: NextRequest) {
@@ -102,7 +103,8 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const body = await request.json();
+  const { data: body, error: parseError } = await parseJsonBody(request);
+  if (parseError) return parseError;
 
   const {
     type,

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Safely parse JSON body from a request.
+ * Returns { data, error } — if the body is malformed JSON, returns a 400 response.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function parseJsonBody<T = any>(
+  request: NextRequest
+): Promise<{ data: T; error: null } | { data: null; error: NextResponse }> {
+  try {
+    const data = await request.json();
+    return { data: data as T, error: null };
+  } catch {
+    return {
+      data: null,
+      error: NextResponse.json(
+        { error: "Invalid JSON in request body" },
+        { status: 400 }
+      ),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `parseJsonBody()` utility in `src/lib/api-utils.ts` that wraps `request.json()` in try-catch
- Replaces all 17 raw `await request.json()` calls across POST/PATCH API routes
- Malformed JSON now returns `{ error: "Invalid JSON in request body" }` with 400 status instead of crashing with 500

## Test plan
- [x] All 176 existing tests pass
- [x] Build clean, lint clean
- [x] Verified no raw `request.json()` calls remain in API routes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)