### PR TITLE
fix: Add safe JSON.parse wrappers across API routes

### DIFF
--- a/src/app/api/auth/login/options/route.ts
+++ b/src/app/api/auth/login/options/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
       allowCredentials: user.credentials.map((cred) => ({
         id: cred.credentialId,
         transports: cred.transports
-          ? JSON.parse(cred.transports)
+          ? (() => { try { return JSON.parse(cred.transports); } catch { return undefined; } })()
           : undefined,
       })),
       userVerification: "preferred",

--- a/src/app/api/auth/login/verify/route.ts
+++ b/src/app/api/auth/login/verify/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest) {
         publicKey: credential.publicKey,
         counter: Number(credential.counter),
         transports: credential.transports
-          ? JSON.parse(credential.transports)
+          ? (() => { try { return JSON.parse(credential.transports); } catch { return undefined; } })()
           : undefined,
       },
     });

--- a/src/app/api/auth/register/verify/route.ts
+++ b/src/app/api/auth/register/verify/route.ts
@@ -23,7 +23,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const userData = JSON.parse(userDataStr);
+    let userData;
+    try {
+      userData = JSON.parse(userDataStr);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid registration data. Please try again." },
+        { status: 400 }
+      );
+    }
     const { rpID, origin } = getWebAuthnConfig();
 
     const verification = await verifyRegistrationResponse({

--- a/src/app/api/reports/[id]/generate/route.ts
+++ b/src/app/api/reports/[id]/generate/route.ts
@@ -65,7 +65,8 @@ export async function POST(
     return NextResponse.json({ error: "Report not found" }, { status: 404 });
   }
 
-  const filters: ReportFilters = JSON.parse(report.filters);
+  let filters: ReportFilters = {};
+  try { filters = JSON.parse(report.filters); } catch { /* invalid JSON, default to empty filters */ }
   const context = await getSpaceContext(user.id);
 
   // Build where clause

--- a/src/app/api/reports/[id]/generated/route.ts
+++ b/src/app/api/reports/[id]/generated/route.ts
@@ -37,9 +37,12 @@ export async function GET(
   });
 
   return NextResponse.json(
-    generated.map((g) => ({
-      ...g,
-      summary: g.summary ? JSON.parse(g.summary) : null,
-    }))
+    generated.map((g) => {
+      let summary = null;
+      if (g.summary) {
+        try { summary = JSON.parse(g.summary); } catch { /* invalid JSON, default to null */ }
+      }
+      return { ...g, summary };
+    })
   );
 }

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -25,9 +25,12 @@ export async function GET(
     return NextResponse.json({ error: "Report not found" }, { status: 404 });
   }
 
+  let filters = {};
+  try { filters = JSON.parse(report.filters); } catch { /* invalid JSON, default to empty */ }
+
   return NextResponse.json({
     ...report,
-    filters: JSON.parse(report.filters),
+    filters,
   });
 }
 
@@ -106,9 +109,12 @@ export async function PATCH(
     data,
   });
 
+  let updatedFilters = {};
+  try { updatedFilters = JSON.parse(updated.filters); } catch { /* invalid JSON, default to empty */ }
+
   return NextResponse.json({
     ...updated,
-    filters: JSON.parse(updated.filters),
+    filters: updatedFilters,
   });
 }
 

--- a/src/app/api/reports/execute-scheduled/route.ts
+++ b/src/app/api/reports/execute-scheduled/route.ts
@@ -88,7 +88,8 @@ export async function POST() {
 
   for (const report of dueReports) {
     try {
-      const filters: ReportFilters = JSON.parse(report.filters);
+      let filters: ReportFilters = {};
+      try { filters = JSON.parse(report.filters); } catch { /* invalid JSON, default to empty filters */ }
       const context = await getSpaceContext(user.id);
 
       // Build where clause (same logic as generate endpoint)

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -23,12 +23,16 @@ export async function GET() {
   });
 
   return NextResponse.json(
-    reports.map((r) => ({
-      ...r,
-      filters: JSON.parse(r.filters),
-      generatedCount: r._count.generatedReports,
-      _count: undefined,
-    }))
+    reports.map((r) => {
+      let filters = {};
+      try { filters = JSON.parse(r.filters); } catch { /* invalid JSON, default to empty */ }
+      return {
+        ...r,
+        filters,
+        generatedCount: r._count.generatedReports,
+        _count: undefined,
+      };
+    })
   );
 }
 
@@ -67,7 +71,7 @@ export async function POST(request: NextRequest) {
   });
 
   return NextResponse.json(
-    { ...report, filters: JSON.parse(report.filters) },
+    { ...report, filters: (() => { try { return JSON.parse(report.filters); } catch { return {}; } })() },
     { status: 201 }
   );
 }


### PR DESCRIPTION
## Summary
- Wraps all bare `JSON.parse()` calls in try-catch blocks across 8 API route files
- Database-stored JSON (report filters, summaries, credential transports) defaults to empty objects/arrays on parse failure
- User-provided cookie data (register verify) returns 400 error on parse failure
- Prevents unhandled crashes from corrupted data

Closes #127

## Files changed
- `src/app/api/reports/route.ts` — 2 locations (GET list, POST response)
- `src/app/api/reports/[id]/route.ts` — 2 locations (GET, PATCH)
- `src/app/api/reports/[id]/generate/route.ts` — 1 location
- `src/app/api/reports/execute-scheduled/route.ts` — 1 location
- `src/app/api/reports/[id]/generated/route.ts` — 1 location
- `src/app/api/auth/login/verify/route.ts` — 1 location
- `src/app/api/auth/login/options/route.ts` — 1 location
- `src/app/api/auth/register/verify/route.ts` — 1 location (returns 400)

## Test plan
- [x] All 224 existing tests pass
- [x] Build succeeds
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)