### PR TITLE
feat: add HTTP security headers to all responses

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,27 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes (covers static assets too)
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-XSS-Protection", value: "1; mode=block" },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), payment=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for middleware security headers and route protection.
+ */
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+function createRequest(path: string, cookies?: Record<string, string>) {
+  const url = `http://localhost:3000${path}`;
+  const req = new NextRequest(url);
+  if (cookies) {
+    for (const [key, value] of Object.entries(cookies)) {
+      req.cookies.set(key, value);
+    }
+  }
+  return req;
+}
+
+const EXPECTED_SECURITY_HEADERS = [
+  "X-Frame-Options",
+  "X-Content-Type-Options",
+  "X-XSS-Protection",
+  "Referrer-Policy",
+  "Permissions-Policy",
+  "Content-Security-Policy",
+];
+
+describe("middleware", () => {
+  describe("security headers", () => {
+    it("adds security headers to public pages", () => {
+      const res = middleware(createRequest("/auth/login"));
+      for (const header of EXPECTED_SECURITY_HEADERS) {
+        expect(res.headers.get(header)).toBeTruthy();
+      }
+    });
+
+    it("adds security headers to protected pages", () => {
+      const res = middleware(
+        createRequest("/dashboard", { ck_session: "valid-token" })
+      );
+      for (const header of EXPECTED_SECURITY_HEADERS) {
+        expect(res.headers.get(header)).toBeTruthy();
+      }
+    });
+
+    it("adds security headers to redirect responses", () => {
+      const res = middleware(createRequest("/dashboard"));
+      // Should redirect to login
+      expect(res.status).toBe(307);
+      for (const header of EXPECTED_SECURITY_HEADERS) {
+        expect(res.headers.get(header)).toBeTruthy();
+      }
+    });
+
+    it("sets X-Frame-Options to DENY", () => {
+      const res = middleware(createRequest("/auth/login"));
+      expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    });
+
+    it("sets X-Content-Type-Options to nosniff", () => {
+      const res = middleware(createRequest("/auth/login"));
+      expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    });
+
+    it("includes frame-ancestors none in CSP", () => {
+      const res = middleware(createRequest("/auth/login"));
+      const csp = res.headers.get("Content-Security-Policy");
+      expect(csp).toContain("frame-ancestors 'none'");
+    });
+
+    it("includes form-action self in CSP", () => {
+      const res = middleware(createRequest("/auth/login"));
+      const csp = res.headers.get("Content-Security-Policy");
+      expect(csp).toContain("form-action 'self'");
+    });
+  });
+
+  describe("route protection", () => {
+    it("allows auth pages without session", () => {
+      const res = middleware(createRequest("/auth/login"));
+      expect(res.status).not.toBe(307);
+    });
+
+    it("allows auth API routes without session", () => {
+      const res = middleware(createRequest("/api/auth/register"));
+      expect(res.status).not.toBe(307);
+    });
+
+    it("allows health check without session", () => {
+      const res = middleware(createRequest("/api/health"));
+      expect(res.status).not.toBe(307);
+    });
+
+    it("allows telegram webhook without session", () => {
+      const res = middleware(createRequest("/api/telegram/webhook"));
+      expect(res.status).not.toBe(307);
+    });
+
+    it("redirects to login when no session cookie", () => {
+      const res = middleware(createRequest("/dashboard"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/auth/login");
+    });
+
+    it("allows access with valid session cookie", () => {
+      const res = middleware(
+        createRequest("/dashboard", { ck_session: "valid-token" })
+      );
+      expect(res.status).not.toBe(307);
+    });
+
+    it("allows static assets without session", () => {
+      const res = middleware(createRequest("/_next/static/chunk.js"));
+      expect(res.status).not.toBe(307);
+    });
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,47 @@
 import { NextRequest, NextResponse } from "next/server";
 
 /**
- * Middleware to protect routes.
+ * Security headers applied to every response.
+ * Protects against clickjacking, MIME sniffing, XSS, and data leaks.
+ */
+const securityHeaders: Record<string, string> = {
+  // Prevent clickjacking — only allow same-origin framing
+  "X-Frame-Options": "DENY",
+  // Block MIME type sniffing
+  "X-Content-Type-Options": "nosniff",
+  // Enable browser XSS filter (legacy browsers)
+  "X-XSS-Protection": "1; mode=block",
+  // Control referrer information leakage
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  // Restrict browser features/APIs
+  "Permissions-Policy":
+    "camera=(), microphone=(), geolocation=(), payment=()",
+  // Content Security Policy — allow self, inline styles (Tailwind), and data URIs for images
+  "Content-Security-Policy": [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join("; "),
+};
+
+/**
+ * Apply security headers to a response.
+ */
+function applySecurityHeaders(response: NextResponse): NextResponse {
+  for (const [key, value] of Object.entries(securityHeaders)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+/**
+ * Middleware to protect routes and add security headers.
  * Redirects unauthenticated users to /auth/login.
  * Auth pages and API routes for auth are excluded.
  */
@@ -15,7 +55,7 @@ export function middleware(req: NextRequest) {
     pathname.startsWith("/api/health") ||
     pathname.startsWith("/api/telegram/webhook")
   ) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next());
   }
 
   // Allow static assets, Next.js internals
@@ -24,17 +64,17 @@ export function middleware(req: NextRequest) {
     pathname.startsWith("/favicon") ||
     pathname.includes(".")
   ) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next());
   }
 
   // Check for session cookie
   const sessionToken = req.cookies.get("ck_session")?.value;
   if (!sessionToken) {
     const loginUrl = new URL("/auth/login", req.url);
-    return NextResponse.redirect(loginUrl);
+    return applySecurityHeaders(NextResponse.redirect(loginUrl));
   }
 
-  return NextResponse.next();
+  return applySecurityHeaders(NextResponse.next());
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Add comprehensive HTTP security headers (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) via middleware and next.config.ts
- All responses now include anti-clickjacking, anti-MIME-sniffing, and content source restrictions
- 14 new middleware tests covering header presence and route protection logic

Closes #134

## Verified
- All 303 tests pass (14 new)
- Lint clean
- Headers confirmed on live dev server via `curl -sI`

## Test plan
- [x] Security headers present on auth pages
- [x] Security headers present on protected pages
- [x] Security headers present on redirect responses
- [x] Route protection redirects unauthenticated users
- [x] Route protection allows public routes (auth, health, webhook)
- [x] CSP includes frame-ancestors none and form-action self

🤖 Generated with [Claude Code](https://claude.com/claude-code)