### PR TITLE
fix: add userId to Receipt model and enforce ownership in API routes

### DIFF
--- a/prisma/migrations/20260328090352_add_receipt_userid/migration.sql
+++ b/prisma/migrations/20260328090352_add_receipt_userid/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `Receipt` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Receipt" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "imagePath" TEXT NOT NULL,
+    "merchant" TEXT,
+    "total" REAL,
+    "currency" TEXT,
+    "rawText" TEXT,
+    "parsedData" TEXT,
+    "processedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Receipt_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Receipt" ("createdAt", "currency", "id", "imagePath", "merchant", "parsedData", "processedAt", "rawText", "total") SELECT "createdAt", "currency", "id", "imagePath", "merchant", "parsedData", "processedAt", "rawText", "total" FROM "Receipt";
+DROP TABLE "Receipt";
+ALTER TABLE "new_Receipt" RENAME TO "Receipt";
+CREATE INDEX "Receipt_userId_idx" ON "Receipt"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   sessions           Session[]
   scheduledTransfers ScheduledTransfer[]
 
+  receipts           Receipt[]
   spaceMemberships SpaceMember[]
   telegramLink     TelegramLink?
   telegramLinkCodes TelegramLinkCode[]
@@ -156,6 +157,7 @@ model Transaction {
 
 model Receipt {
   id          String   @id @default(cuid())
+  userId      String
   imagePath   String
   merchant    String?
   total       Float?
@@ -165,8 +167,11 @@ model Receipt {
   processedAt DateTime?
   createdAt   DateTime @default(now())
 
+  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   transactions  Transaction[]
   productPrices ProductPrice[]
+
+  @@index([userId])
 }
 
 // ─── Products & Price Tracking ──────────────────────────────────────

--- a/src/app/api/__tests__/receipts.test.ts
+++ b/src/app/api/__tests__/receipts.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for /api/receipts routes.
+ * Tests user ownership enforcement on receipt CRUD operations.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createRequest,
+  parseResponse,
+} from "./helpers";
+
+// ── Hoisted mocks ──
+
+const { mockUser, mockReceiptModel, mockTransactionModel } = vi.hoisted(() => {
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockReceiptModel: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
+      delete: vi.fn().mockResolvedValue(null),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    mockTransactionModel: {
+      findMany: vi.fn().mockResolvedValue([]),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: vi.fn().mockResolvedValue(mockUser),
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+  getCurrentUser: vi.fn().mockResolvedValue(mockUser),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    receipt: mockReceiptModel,
+    transaction: mockTransactionModel,
+  },
+}));
+
+// ── Tests ──
+
+describe("GET /api/receipts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filters receipts by current user's ID", async () => {
+    const mockReceipts = [
+      {
+        id: "rec-1",
+        userId: "user-1",
+        imagePath: "/uploads/receipts/test.jpg",
+        merchant: "Test Store",
+        total: 42.5,
+        currency: "USD",
+        createdAt: new Date("2026-03-01"),
+        transactions: [],
+      },
+    ];
+    mockReceiptModel.findMany.mockResolvedValueOnce(mockReceipts);
+    mockReceiptModel.count.mockResolvedValueOnce(1);
+
+    const { GET } = await import("../receipts/route");
+    const request = createRequest("http://localhost:3000/api/receipts");
+    const response = await GET(request);
+    const { status, data } = await parseResponse<{
+      receipts: unknown[];
+      total: number;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.receipts).toHaveLength(1);
+
+    // Verify findMany was called with userId filter
+    expect(mockReceiptModel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1" },
+      })
+    );
+
+    // Verify count was also scoped to user
+    expect(mockReceiptModel.count).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
+  });
+
+  it("respects limit and offset params", async () => {
+    mockReceiptModel.findMany.mockResolvedValueOnce([]);
+    mockReceiptModel.count.mockResolvedValueOnce(0);
+
+    const { GET } = await import("../receipts/route");
+    const request = createRequest(
+      "http://localhost:3000/api/receipts?limit=5&offset=10"
+    );
+    await GET(request);
+
+    expect(mockReceiptModel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 5,
+        skip: 10,
+        where: { userId: "user-1" },
+      })
+    );
+  });
+});
+
+describe("GET /api/receipts/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns receipt when owned by current user", async () => {
+    const mockReceipt = {
+      id: "rec-1",
+      userId: "user-1",
+      imagePath: "/uploads/receipts/test.jpg",
+      merchant: "Test Store",
+      total: 42.5,
+      currency: "USD",
+      parsedData: null,
+      createdAt: new Date("2026-03-01"),
+      transactions: [],
+    };
+    mockReceiptModel.findUnique.mockResolvedValueOnce(mockReceipt);
+
+    const { GET } = await import("../receipts/[id]/route");
+    const request = createRequest("http://localhost:3000/api/receipts/rec-1");
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "rec-1" }),
+    });
+    const { status } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(mockReceiptModel.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "rec-1", userId: "user-1" },
+      })
+    );
+  });
+
+  it("returns 404 when receipt belongs to another user", async () => {
+    // findUnique with userId filter returns null for another user's receipt
+    mockReceiptModel.findUnique.mockResolvedValueOnce(null);
+
+    const { GET } = await import("../receipts/[id]/route");
+    const request = createRequest(
+      "http://localhost:3000/api/receipts/rec-other"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ id: "rec-other" }),
+    });
+    const { status, data } = await parseResponse<{ error: string }>(response);
+
+    expect(status).toBe(404);
+    expect(data.error).toBe("Receipt not found");
+  });
+});
+
+describe("DELETE /api/receipts/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes receipt when owned by current user", async () => {
+    const mockReceipt = {
+      id: "rec-1",
+      userId: "user-1",
+      imagePath: "/uploads/receipts/test.jpg",
+    };
+    mockReceiptModel.findUnique.mockResolvedValueOnce(mockReceipt);
+    mockReceiptModel.delete.mockResolvedValueOnce(mockReceipt);
+
+    const { DELETE } = await import("../receipts/[id]/route");
+    const request = createRequest("http://localhost:3000/api/receipts/rec-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: "rec-1" }),
+    });
+    const { status, data } = await parseResponse<{ success: boolean }>(
+      response
+    );
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify ownership check in findUnique
+    expect(mockReceiptModel.findUnique).toHaveBeenCalledWith({
+      where: { id: "rec-1", userId: "user-1" },
+    });
+
+    // Verify delete also scoped to user
+    expect(mockReceiptModel.delete).toHaveBeenCalledWith({
+      where: { id: "rec-1", userId: "user-1" },
+    });
+  });
+
+  it("returns 404 when deleting another user's receipt", async () => {
+    mockReceiptModel.findUnique.mockResolvedValueOnce(null);
+
+    const { DELETE } = await import("../receipts/[id]/route");
+    const request = createRequest(
+      "http://localhost:3000/api/receipts/rec-other",
+      { method: "DELETE" }
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: "rec-other" }),
+    });
+    const { status, data } = await parseResponse<{ error: string }>(response);
+
+    expect(status).toBe(404);
+    expect(data.error).toBe("Receipt not found");
+  });
+});

--- a/src/app/api/products/extract/route.ts
+++ b/src/app/api/products/extract/route.ts
@@ -22,13 +22,11 @@ export async function POST() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Get all receipts that have parsedData, linked to the user via transactions
+  // Get all receipts that have parsedData, owned by the current user
   const receipts = await db.receipt.findMany({
     where: {
+      userId: user.id,
       parsedData: { not: null },
-      transactions: {
-        some: { userId: user.id },
-      },
     },
     select: {
       id: true,

--- a/src/app/api/receipts/[id]/parse/route.ts
+++ b/src/app/api/receipts/[id]/parse/route.ts
@@ -18,10 +18,10 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  await requireUser();
+  const user = await requireUser();
   const { id } = await params;
 
-  const receipt = await db.receipt.findUnique({ where: { id } });
+  const receipt = await db.receipt.findUnique({ where: { id, userId: user.id } });
   if (!receipt) {
     return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
   }

--- a/src/app/api/receipts/[id]/route.ts
+++ b/src/app/api/receipts/[id]/route.ts
@@ -7,11 +7,11 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  await requireUser();
+  const user = await requireUser();
   const { id } = await params;
 
   const receipt = await db.receipt.findUnique({
-    where: { id },
+    where: { id, userId: user.id },
     include: {
       transactions: {
         select: {
@@ -55,10 +55,10 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  await requireUser();
+  const user = await requireUser();
   const { id } = await params;
 
-  const receipt = await db.receipt.findUnique({ where: { id } });
+  const receipt = await db.receipt.findUnique({ where: { id, userId: user.id } });
   if (!receipt) {
     return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
   }
@@ -69,7 +69,7 @@ export async function DELETE(
     data: { receiptId: null },
   });
 
-  await db.receipt.delete({ where: { id } });
+  await db.receipt.delete({ where: { id, userId: user.id } });
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -20,15 +20,18 @@ function isAllowedType(type: string): type is AllowedMimeType {
   return ALLOWED_TYPES.includes(type as AllowedMimeType);
 }
 
-// GET /api/receipts — list receipts
+// GET /api/receipts — list receipts for current user
 export async function GET(request: NextRequest) {
-  await requireUser();
+  const user = await requireUser();
   const { searchParams } = new URL(request.url);
   const limit = parseInt(searchParams.get("limit") || "20", 10);
   const offset = parseInt(searchParams.get("offset") || "0", 10);
 
+  const where = { userId: user.id };
+
   const [receipts, total] = await Promise.all([
     db.receipt.findMany({
+      where,
       orderBy: { createdAt: "desc" },
       take: limit,
       skip: offset,
@@ -43,7 +46,7 @@ export async function GET(request: NextRequest) {
         },
       },
     }),
-    db.receipt.count(),
+    db.receipt.count({ where }),
   ]);
 
   return NextResponse.json({ receipts, total });
@@ -51,7 +54,7 @@ export async function GET(request: NextRequest) {
 
 // POST /api/receipts — upload receipt image and optionally parse with AI
 export async function POST(request: NextRequest) {
-  await requireUser();
+  const user = await requireUser();
 
   const contentType = request.headers.get("content-type") || "";
   if (!contentType.includes("multipart/form-data")) {
@@ -125,6 +128,7 @@ export async function POST(request: NextRequest) {
   // Create receipt record
   const receipt = await db.receipt.create({
     data: {
+      userId: user.id,
       imagePath: publicPath,
       merchant: parsedData?.merchant || null,
       total: parsedData?.total || null,

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -971,6 +971,7 @@ function registerHandlers(bot: Bot) {
       // Store receipt in database
       const receipt = await db.receipt.create({
         data: {
+          userId: user.id,
           imagePath: `telegram://${photo.file_id}`,
           merchant: parsed.merchant,
           total: parsed.total,


### PR DESCRIPTION
## Summary

- **Security fix**: Added `userId` field to `Receipt` model — receipts were previously global (no user association), allowing any authenticated user to view, delete, or re-parse any receipt
- Updated all receipt API routes (`GET /api/receipts`, `GET /api/receipts/[id]`, `DELETE /api/receipts/[id]`, `POST /api/receipts`, `POST /api/receipts/[id]/parse`) to scope queries by `userId`
- Updated Telegram bot receipt creation to include `userId`
- Simplified `POST /api/products/extract` to use direct `userId` filter instead of indirect transaction join
- Added 6 integration tests verifying ownership enforcement

## Test plan

- [x] Build passes (clean)
- [x] Lint passes (clean)
- [x] All 309 tests pass (303 existing + 6 new)
- [ ] Verify GET /api/receipts only returns current user's receipts
- [ ] Verify GET /api/receipts/[id] returns 404 for another user's receipt
- [ ] Verify DELETE /api/receipts/[id] returns 404 for another user's receipt

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)