### PR TITLE
perf: add composite database indexes for common query patterns

### DIFF
--- a/prisma/migrations/20260328090821_add_composite_indexes/migration.sql
+++ b/prisma/migrations/20260328090821_add_composite_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "ProductPrice_productId_date_idx" ON "ProductPrice"("productId", "date");
+
+-- CreateIndex
+CREATE INDEX "Receipt_userId_createdAt_idx" ON "Receipt"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "RecurringRule_isActive_nextExecution_idx" ON "RecurringRule"("isActive", "nextExecution");
+
+-- CreateIndex
+CREATE INDEX "Transaction_userId_date_idx" ON "Transaction"("userId", "date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,7 @@ model Transaction {
   recurring   RecurringRule?    @relation(fields: [recurringId], references: [id])
 
   @@index([userId])
+  @@index([userId, date])
   @@index([categoryId])
   @@index([fromAccountId])
   @@index([toAccountId])
@@ -172,6 +173,7 @@ model Receipt {
   productPrices ProductPrice[]
 
   @@index([userId])
+  @@index([userId, createdAt])
 }
 
 // ─── Products & Price Tracking ──────────────────────────────────────
@@ -205,6 +207,7 @@ model ProductPrice {
   receipt Receipt? @relation(fields: [receiptId], references: [id], onDelete: SetNull)
 
   @@index([productId])
+  @@index([productId, date])
   @@index([date])
   @@index([receiptId])
 }
@@ -222,6 +225,8 @@ model RecurringRule {
   createdAt      DateTime @default(now())
 
   transactions Transaction[]
+
+  @@index([isActive, nextExecution])
 }
 
 // ─── Scheduled Transfers ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added composite indexes for frequently queried column combinations:
  - `Transaction(userId, date)` — analytics, balance history, filtered transaction lists
  - `Receipt(userId, createdAt)` — receipt list pagination
  - `ProductPrice(productId, date)` — price history chart queries
  - `RecurringRule(isActive, nextExecution)` — background job scheduling queries

## Test plan

- [x] Build passes
- [x] All 309 tests pass
- [x] Migration applies cleanly

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)