### PR TITLE
fix: Consistent error handling across all API routes

### DIFF
--- a/src/app/api/__tests__/categories.test.ts
+++ b/src/app/api/__tests__/categories.test.ts
@@ -39,7 +39,7 @@ const { mockUser, mockCategoryModel, mockTransactionModel } = vi.hoisted(
 );
 
 vi.mock("@/lib/auth", () => ({
-  requireUser: vi.fn().mockResolvedValue(mockUser),
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
 }));
 
 vi.mock("@/lib/category-normalize", () => ({

--- a/src/app/api/__tests__/receipts.test.ts
+++ b/src/app/api/__tests__/receipts.test.ts
@@ -39,7 +39,6 @@ const { mockUser, mockReceiptModel, mockTransactionModel } = vi.hoisted(() => {
 });
 
 vi.mock("@/lib/auth", () => ({
-  requireUser: vi.fn().mockResolvedValue(mockUser),
   requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
   getCurrentUser: vi.fn().mockResolvedValue(mockUser),
 }));

--- a/src/app/api/__tests__/scheduled-transfers.test.ts
+++ b/src/app/api/__tests__/scheduled-transfers.test.ts
@@ -37,7 +37,7 @@ const { mockUser, mockScheduledTransferModel, mockAccountModel } = vi.hoisted(
 );
 
 vi.mock("@/lib/auth", () => ({
-  requireUser: vi.fn().mockResolvedValue(mockUser),
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
 }));
 
 vi.mock("@/lib/schedule", () => ({

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { parseAndValidateBody } from "@/lib/api-utils";
 import { updateAccountSchema } from "@/lib/validations";
 
@@ -9,7 +9,10 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const account = await db.account.findFirst({
@@ -28,7 +31,10 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const existing = await db.account.findFirst({
@@ -67,7 +73,10 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error: delAuthError } = await requireApiUser();
+  if (delAuthError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const existing = await db.account.findFirst({

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { normalizeName } from "@/lib/category-normalize";
 import { parseJsonBody } from "@/lib/api-utils";
 
@@ -9,7 +9,10 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
   const { data: body, error: parseError } = await parseJsonBody(request);
   if (parseError) return parseError;
@@ -65,7 +68,10 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   // Verify category belongs to user

--- a/src/app/api/categories/merge/route.ts
+++ b/src/app/api/categories/merge/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categories/merge — merge source category into target
 export async function POST(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { data: body, error: parseError } = await parseJsonBody(request);
   if (parseError) return parseError;
 

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 
 const DEFAULT_CATEGORIES = [
   // Expense categories
@@ -26,7 +26,10 @@ const DEFAULT_CATEGORIES = [
 
 // GET /api/categories — list categories, seeding defaults if empty
 export async function GET() {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   let categories = await db.category.findMany({
     where: { userId: user.id },

--- a/src/app/api/categorize/feedback/route.ts
+++ b/src/app/api/categorize/feedback/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categorize/feedback — store user correction of AI suggestion
 export async function POST(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { data: body, error: parseError } = await parseJsonBody(request);
   if (parseError) return parseError;
 

--- a/src/app/api/categorize/route.ts
+++ b/src/app/api/categorize/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { categorizeTransaction } from "@/lib/categorize";
 import { findSimilar, normalizeName } from "@/lib/category-normalize";
 import { parseJsonBody } from "@/lib/api-utils";
 
 // POST /api/categorize — AI-powered category suggestion
 export async function POST(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { data: body, error: parseError } = await parseJsonBody(request);
   if (parseError) return parseError;
 

--- a/src/app/api/net-worth/route.ts
+++ b/src/app/api/net-worth/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { fetchExchangeRate } from "@/lib/exchange-rate";
 
 export async function GET(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const baseCurrency = (
     request.nextUrl.searchParams.get("baseCurrency") || "USD"
   ).toUpperCase();

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -16,37 +16,45 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const url = req.nextUrl;
-  const unreadOnly = url.searchParams.get("unreadOnly") === "true";
-  const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 100);
-  const offset = Number(url.searchParams.get("offset")) || 0;
+  try {
+    const url = req.nextUrl;
+    const unreadOnly = url.searchParams.get("unreadOnly") === "true";
+    const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 100);
+    const offset = Number(url.searchParams.get("offset")) || 0;
 
-  const context = await getSpaceContext(user.id);
+    const context = await getSpaceContext(user.id);
 
-  const where = {
-    userId: user.id,
-    ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
-    ...(unreadOnly ? { read: false } : {}),
-  };
+    const where = {
+      userId: user.id,
+      ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
+      ...(unreadOnly ? { read: false } : {}),
+    };
 
-  const [notifications, total, unreadCount] = await Promise.all([
-    db.notification.findMany({
-      where,
-      orderBy: { createdAt: "desc" },
-      take: limit,
-      skip: offset,
-    }),
-    db.notification.count({ where }),
-    db.notification.count({
-      where: {
-        userId: user.id,
-        ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
-        read: false,
-      },
-    }),
-  ]);
+    const [notifications, total, unreadCount] = await Promise.all([
+      db.notification.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+      }),
+      db.notification.count({ where }),
+      db.notification.count({
+        where: {
+          userId: user.id,
+          ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
+          read: false,
+        },
+      }),
+    ]);
 
-  return NextResponse.json({ notifications, total, unreadCount });
+    return NextResponse.json({ notifications, total, unreadCount });
+  } catch (err) {
+    console.error("Failed to fetch notifications:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch notifications" },
+      { status: 500 }
+    );
+  }
 }
 
 /**
@@ -59,22 +67,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await req.json().catch(() => ({}));
+  try {
+    const body = await req.json().catch(() => ({}));
 
-  if (body.action === "mark-all-read") {
-    const context = await getSpaceContext(user.id);
+    if (body.action === "mark-all-read") {
+      const context = await getSpaceContext(user.id);
 
-    await db.notification.updateMany({
-      where: {
-        userId: user.id,
-        ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
-        read: false,
-      },
-      data: { read: true },
-    });
+      await db.notification.updateMany({
+        where: {
+          userId: user.id,
+          ...(context.spaceId ? { spaceId: context.spaceId } : { spaceId: null }),
+          read: false,
+        },
+        data: { read: true },
+      });
 
-    return NextResponse.json({ success: true });
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  } catch (err) {
+    console.error("Failed to update notifications:", err);
+    return NextResponse.json(
+      { error: "Failed to update notifications" },
+      { status: 500 }
+    );
   }
-
-  return NextResponse.json({ error: "Invalid action" }, { status: 400 });
 }

--- a/src/app/api/products/extract/route.ts
+++ b/src/app/api/products/extract/route.ts
@@ -50,7 +50,9 @@ export async function POST() {
     let parsed: ParsedData;
     try {
       parsed = JSON.parse(receipt.parsedData!) as ParsedData;
-    } catch {
+    } catch (err) {
+      console.error(`Invalid parsedData JSON in receipt ${receipt.id}:`, err);
+      skipped++;
       continue;
     }
 

--- a/src/app/api/receipts/[id]/parse/route.ts
+++ b/src/app/api/receipts/[id]/parse/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { readFile } from "fs/promises";
 import path from "path";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { parseReceiptImage, ParsedReceipt } from "@/lib/receipt-parser";
 
 const ALLOWED_MIME: Record<string, "image/jpeg" | "image/png" | "image/webp" | "image/gif"> = {
@@ -18,7 +18,10 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const receipt = await db.receipt.findUnique({ where: { id, userId: user.id } });
@@ -49,7 +52,16 @@ export async function POST(
   }
 
   const base64 = buffer.toString("base64");
-  const parsedData: ParsedReceipt = await parseReceiptImage(base64, mimeType);
+  let parsedData: ParsedReceipt;
+  try {
+    parsedData = await parseReceiptImage(base64, mimeType);
+  } catch (err) {
+    console.error("Receipt parsing failed:", err);
+    return NextResponse.json(
+      { error: "Failed to parse receipt image. The AI service may be unavailable." },
+      { status: 502 }
+    );
+  }
 
   // Update receipt record with parsed data
   const updated = await db.receipt.update({

--- a/src/app/api/receipts/[id]/route.ts
+++ b/src/app/api/receipts/[id]/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 
 // GET /api/receipts/[id] — get a single receipt with parsed data and linked transactions
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const receipt = await db.receipt.findUnique({
@@ -55,7 +58,10 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
 
   const receipt = await db.receipt.findUnique({ where: { id, userId: user.id } });

--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { parseReceiptImage, ParsedReceipt } from "@/lib/receipt-parser";
 
 const UPLOAD_DIR = path.join(process.cwd(), "public", "uploads", "receipts");
@@ -22,7 +22,10 @@ function isAllowedType(type: string): type is AllowedMimeType {
 
 // GET /api/receipts — list receipts for current user
 export async function GET(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { searchParams } = new URL(request.url);
   const limit = parseInt(searchParams.get("limit") || "20", 10);
   const offset = parseInt(searchParams.get("offset") || "0", 10);
@@ -54,7 +57,10 @@ export async function GET(request: NextRequest) {
 
 // POST /api/receipts — upload receipt image and optionally parse with AI
 export async function POST(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const contentType = request.headers.get("content-type") || "";
   if (!contentType.includes("multipart/form-data")) {

--- a/src/app/api/scheduled-transfers/[id]/execute/route.ts
+++ b/src/app/api/scheduled-transfers/[id]/execute/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { executeScheduledTransfer } from "@/lib/execute-scheduled-transfer";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 // POST /api/scheduled-transfers/[id]/execute — manually execute a single scheduled transfer
 export async function POST(request: NextRequest, context: RouteContext) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params;
 
   try {

--- a/src/app/api/scheduled-transfers/[id]/route.ts
+++ b/src/app/api/scheduled-transfers/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { calculateNextExecution } from "@/lib/schedule";
 import { parseJsonBody } from "@/lib/api-utils";
 
@@ -9,7 +9,10 @@ type RouteContext = { params: Promise<{ id: string }> };
 // ─── GET /api/scheduled-transfers/[id] ──────────────────────────────
 
 export async function GET(request: NextRequest, context: RouteContext) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params;
 
   const schedule = await db.scheduledTransfer.findFirst({
@@ -37,7 +40,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
 // ─── PATCH /api/scheduled-transfers/[id] ────────────────────────────
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params;
   const { data: body, error: parseError } = await parseJsonBody(request);
   if (parseError) return parseError;
@@ -171,7 +177,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 // ─── DELETE /api/scheduled-transfers/[id] ───────────────────────────
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
-  const user = await requireUser();
+  const { user, error: delAuthError } = await requireApiUser();
+  if (delAuthError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params;
 
   const existing = await db.scheduledTransfer.findFirst({

--- a/src/app/api/scheduled-transfers/execute/route.ts
+++ b/src/app/api/scheduled-transfers/execute/route.ts
@@ -1,16 +1,27 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { executeDueScheduledTransfers } from "@/lib/execute-scheduled-transfer";
 
 // POST /api/scheduled-transfers/execute — execute all due scheduled transfers
 export async function POST() {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  const result = await executeDueScheduledTransfers(user.id);
+  try {
+    const result = await executeDueScheduledTransfers(user.id);
 
-  return NextResponse.json({
-    executed: result.executed.length,
-    errors: result.errors.length,
-    details: result,
-  });
+    return NextResponse.json({
+      executed: result.executed.length,
+      errors: result.errors.length,
+      details: result,
+    });
+  } catch (err) {
+    console.error("Scheduled transfer execution error:", err);
+    return NextResponse.json(
+      { error: "Failed to execute scheduled transfers" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/scheduled-transfers/route.ts
+++ b/src/app/api/scheduled-transfers/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { requireUser } from "@/lib/auth";
+import { requireApiUser } from "@/lib/auth";
 import { calculateNextExecution } from "@/lib/schedule";
 import { parseAndValidateBody } from "@/lib/api-utils";
 import { createScheduledTransferSchema } from "@/lib/validations";
@@ -8,7 +8,10 @@ import { createScheduledTransferSchema } from "@/lib/validations";
 // ─── GET /api/scheduled-transfers ───────────────────────────────────
 
 export async function GET(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error } = await requireApiUser();
+  if (error) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { searchParams } = new URL(request.url);
 
   const active = searchParams.get("active"); // "true" or "false"
@@ -36,7 +39,10 @@ export async function GET(request: NextRequest) {
 // ─── POST /api/scheduled-transfers ──────────────────────────────────
 
 export async function POST(request: NextRequest) {
-  const user = await requireUser();
+  const { user, error: authError } = await requireApiUser();
+  if (authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { data: body, error: parseError } = await parseAndValidateBody(request, createScheduledTransferSchema);
   if (parseError) return parseError;
 


### PR DESCRIPTION
## Summary

- **Replaced `requireUser()` with `requireApiUser()` in all 13 API route files** (22 handler functions). `requireUser()` uses Next.js `redirect()` which returns an HTML redirect response — API routes should return JSON 401 errors instead.
- **Added try-catch error handling** to routes that were missing it:
  - `/api/scheduled-transfers/execute` — was completely unwrapped
  - `/api/receipts/[id]/parse` — `parseReceiptImage()` call could throw on API failure
  - `/api/notifications` — GET and POST handlers lacked database error handling
  - `/api/products/extract` — silent `catch { continue }` now logs invalid JSON before skipping
- **Updated test mocks** in categories, scheduled-transfers, and receipts test files to match the new auth pattern

Closes #140

## Test plan

- [x] All 309 tests pass
- [x] Lint clean
- [x] Build clean
- [ ] Verify API routes return JSON 401 when unauthenticated (not HTML redirect)
- [ ] Verify scheduled transfer execution errors return proper 500 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)