### PR TITLE
test: integration tests for settings, products, net-worth APIs

### DIFF
--- a/src/app/api/__tests__/net-worth.test.ts
+++ b/src/app/api/__tests__/net-worth.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Integration tests for /api/net-worth route.
+ * Tests net worth calculation with multi-currency support.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUser, mockAccountModel, mockFetchExchangeRate } = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockAccountModel: createModel(),
+    mockFetchExchangeRate: vi.fn().mockResolvedValue(1.0),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    account: mockAccountModel,
+  },
+}));
+
+vi.mock("@/lib/exchange-rate", () => ({
+  fetchExchangeRate: mockFetchExchangeRate,
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────────
+
+import { GET } from "../net-worth/route";
+
+// ── Test data factories ──────────────────────────────────────────────────────
+
+function createAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "acc-1",
+    userId: "user-1",
+    name: "Checking",
+    type: "bank",
+    currency: "USD",
+    balance: 1000,
+    isArchived: false,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("/api/net-worth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/net-worth", () => {
+    it("returns net worth for single-currency accounts", async () => {
+      const accounts = [
+        createAccount({ id: "acc-1", balance: 1000 }),
+        createAccount({ id: "acc-2", balance: 500, name: "Savings" }),
+      ];
+      mockAccountModel.findMany.mockResolvedValue(accounts);
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { status, data } = await parseResponse<{
+        baseCurrency: string;
+        totalNetWorth: number;
+        breakdown: Array<{
+          currency: string;
+          originalAmount: number;
+          convertedAmount: number;
+          exchangeRate: number;
+        }>;
+        accountCount: number;
+        hasConversionErrors: boolean;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.baseCurrency).toBe("USD");
+      expect(data.totalNetWorth).toBe(1500);
+      expect(data.accountCount).toBe(2);
+      expect(data.hasConversionErrors).toBe(false);
+      expect(data.breakdown).toHaveLength(1);
+      expect(data.breakdown[0].currency).toBe("USD");
+      expect(data.breakdown[0].originalAmount).toBe(1500);
+      expect(data.breakdown[0].exchangeRate).toBe(1);
+    });
+
+    it("converts multi-currency accounts", async () => {
+      const accounts = [
+        createAccount({ id: "acc-1", balance: 1000, currency: "USD" }),
+        createAccount({ id: "acc-2", balance: 800, currency: "EUR" }),
+      ];
+      mockAccountModel.findMany.mockResolvedValue(accounts);
+      mockFetchExchangeRate.mockResolvedValue(1.1); // EUR -> USD rate
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { status, data } = await parseResponse<{
+        totalNetWorth: number;
+        breakdown: Array<{
+          currency: string;
+          originalAmount: number;
+          convertedAmount: number;
+          exchangeRate: number;
+        }>;
+        hasConversionErrors: boolean;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.totalNetWorth).toBe(1000 + 800 * 1.1);
+      expect(data.breakdown).toHaveLength(2);
+      expect(data.hasConversionErrors).toBe(false);
+
+      // Base currency comes first
+      const usdBreakdown = data.breakdown.find((b) => b.currency === "USD");
+      const eurBreakdown = data.breakdown.find((b) => b.currency === "EUR");
+
+      expect(usdBreakdown?.originalAmount).toBe(1000);
+      expect(usdBreakdown?.exchangeRate).toBe(1);
+      expect(eurBreakdown?.originalAmount).toBe(800);
+      expect(eurBreakdown?.convertedAmount).toBeCloseTo(880, 2);
+      expect(eurBreakdown?.exchangeRate).toBe(1.1);
+    });
+
+    it("uses custom baseCurrency from query param", async () => {
+      const accounts = [
+        createAccount({ id: "acc-1", balance: 1000, currency: "EUR" }),
+      ];
+      mockAccountModel.findMany.mockResolvedValue(accounts);
+
+      const req = createRequest(
+        "http://localhost:3000/api/net-worth?baseCurrency=EUR"
+      );
+      const res = await GET(req);
+      const { status, data } = await parseResponse<{
+        baseCurrency: string;
+        totalNetWorth: number;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.baseCurrency).toBe("EUR");
+      expect(data.totalNetWorth).toBe(1000);
+      // No exchange rate call needed since account currency matches base
+      expect(mockFetchExchangeRate).not.toHaveBeenCalled();
+    });
+
+    it("handles exchange rate failures gracefully", async () => {
+      const accounts = [
+        createAccount({ id: "acc-1", balance: 1000, currency: "USD" }),
+        createAccount({ id: "acc-2", balance: 500, currency: "XYZ" }),
+      ];
+      mockAccountModel.findMany.mockResolvedValue(accounts);
+      mockFetchExchangeRate.mockResolvedValue(null); // Rate not available
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { status, data } = await parseResponse<{
+        totalNetWorth: number;
+        hasConversionErrors: boolean;
+        breakdown: Array<{
+          currency: string;
+          convertedAmount: number | null;
+          exchangeRate: number | null;
+        }>;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.hasConversionErrors).toBe(true);
+      expect(data.totalNetWorth).toBe(1000); // Only USD counted
+
+      const xyzBreakdown = data.breakdown.find((b) => b.currency === "XYZ");
+      expect(xyzBreakdown?.convertedAmount).toBeNull();
+      expect(xyzBreakdown?.exchangeRate).toBeNull();
+    });
+
+    it("returns zero net worth when no accounts", async () => {
+      mockAccountModel.findMany.mockResolvedValue([]);
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { status, data } = await parseResponse<{
+        totalNetWorth: number;
+        accountCount: number;
+        breakdown: unknown[];
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.totalNetWorth).toBe(0);
+      expect(data.accountCount).toBe(0);
+      expect(data.breakdown).toHaveLength(0);
+    });
+
+    it("excludes archived accounts", async () => {
+      mockAccountModel.findMany.mockResolvedValue([]);
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      await GET(req);
+
+      expect(mockAccountModel.findMany).toHaveBeenCalledWith({
+        where: { userId: "user-1", isArchived: false },
+      });
+    });
+
+    it("uppercases baseCurrency query param", async () => {
+      mockAccountModel.findMany.mockResolvedValue([]);
+
+      const req = createRequest(
+        "http://localhost:3000/api/net-worth?baseCurrency=eur"
+      );
+      const res = await GET(req);
+      const { data } = await parseResponse<{ baseCurrency: string }>(res);
+
+      expect(data.baseCurrency).toBe("EUR");
+    });
+
+    it("aggregates balances from same-currency accounts", async () => {
+      const accounts = [
+        createAccount({ id: "acc-1", balance: 1000, currency: "USD" }),
+        createAccount({ id: "acc-2", balance: 2000, currency: "USD" }),
+        createAccount({ id: "acc-3", balance: 500, currency: "USD" }),
+      ];
+      mockAccountModel.findMany.mockResolvedValue(accounts);
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { data } = await parseResponse<{
+        totalNetWorth: number;
+        breakdown: Array<{ currency: string; originalAmount: number }>;
+      }>(res);
+
+      expect(data.totalNetWorth).toBe(3500);
+      expect(data.breakdown).toHaveLength(1);
+      expect(data.breakdown[0].originalAmount).toBe(3500);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const { requireApiUser } = await import("@/lib/auth");
+      vi.mocked(requireApiUser).mockResolvedValueOnce({
+        user: null as never,
+        error: true as never,
+      });
+
+      const req = createRequest("http://localhost:3000/api/net-worth");
+      const res = await GET(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(401);
+    });
+  });
+});

--- a/src/app/api/__tests__/products.test.ts
+++ b/src/app/api/__tests__/products.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Integration tests for /api/products routes.
+ * Tests GET (list/search) and GET /api/products/[id]/prices (price history).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUser, mockProductModel, mockProductPriceModel } = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockProductModel: createModel(),
+    mockProductPriceModel: createModel(),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    product: mockProductModel,
+    productPrice: mockProductPriceModel,
+  },
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────────
+
+import { GET as listProducts } from "../products/route";
+import { GET as getProductPrices } from "../products/[id]/prices/route";
+
+// ── Test data factories ──────────────────────────────────────────────────────
+
+function createMockProduct(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "prod-1",
+    userId: "user-1",
+    name: "Whole Milk 1L",
+    normalizedName: "whole milk 1l",
+    prices: [
+      {
+        unitPrice: 3.49,
+        currency: "USD",
+        merchant: "Whole Foods",
+        date: new Date("2026-03-01"),
+      },
+    ],
+    _count: { prices: 5 },
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-03-01"),
+    ...overrides,
+  };
+}
+
+function createMockPrice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "price-1",
+    unitPrice: 3.49,
+    currency: "USD",
+    merchant: "Whole Foods",
+    date: new Date("2026-03-01"),
+    receiptId: null,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("/api/products", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/products", () => {
+    it("returns empty list when no products", async () => {
+      mockProductModel.findMany.mockResolvedValue([]);
+      mockProductModel.count.mockResolvedValue(0);
+
+      const req = createRequest("http://localhost:3000/api/products");
+      const res = await listProducts(req);
+      const { status, data } = await parseResponse<{
+        data: unknown[];
+        total: number;
+        limit: number;
+        offset: number;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.data).toEqual([]);
+      expect(data.total).toBe(0);
+      expect(data.limit).toBe(50);
+      expect(data.offset).toBe(0);
+    });
+
+    it("returns products with latest price", async () => {
+      const product = createMockProduct();
+      mockProductModel.findMany.mockResolvedValue([product]);
+      mockProductModel.count.mockResolvedValue(1);
+
+      const req = createRequest("http://localhost:3000/api/products");
+      const res = await listProducts(req);
+      const { status, data } = await parseResponse<{
+        data: Array<{
+          id: string;
+          name: string;
+          normalizedName: string;
+          latestPrice: { unitPrice: number } | null;
+          observationCount: number;
+        }>;
+        total: number;
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].id).toBe("prod-1");
+      expect(data.data[0].name).toBe("Whole Milk 1L");
+      expect(data.data[0].latestPrice?.unitPrice).toBe(3.49);
+      expect(data.data[0].observationCount).toBe(5);
+      expect(data.total).toBe(1);
+    });
+
+    it("filters by search query", async () => {
+      mockProductModel.findMany.mockResolvedValue([]);
+      mockProductModel.count.mockResolvedValue(0);
+
+      const req = createRequest("http://localhost:3000/api/products?q=milk");
+      const res = await listProducts(req);
+
+      expect(mockProductModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: "user-1",
+            normalizedName: { contains: "milk" },
+          },
+        })
+      );
+    });
+
+    it("applies pagination params", async () => {
+      mockProductModel.findMany.mockResolvedValue([]);
+      mockProductModel.count.mockResolvedValue(0);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products?limit=10&offset=20"
+      );
+      const res = await listProducts(req);
+      const { data } = await parseResponse<{
+        limit: number;
+        offset: number;
+      }>(res);
+
+      expect(data.limit).toBe(10);
+      expect(data.offset).toBe(20);
+      expect(mockProductModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 20,
+        })
+      );
+    });
+
+    it("clamps limit to valid range", async () => {
+      mockProductModel.findMany.mockResolvedValue([]);
+      mockProductModel.count.mockResolvedValue(0);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products?limit=500"
+      );
+      const res = await listProducts(req);
+      const { data } = await parseResponse<{ limit: number }>(res);
+
+      expect(data.limit).toBe(200);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const { requireApiUser } = await import("@/lib/auth");
+      vi.mocked(requireApiUser).mockResolvedValueOnce({
+        user: null as never,
+        error: true as never,
+      });
+
+      const req = createRequest("http://localhost:3000/api/products");
+      const res = await listProducts(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(401);
+    });
+  });
+
+  describe("GET /api/products/[id]/prices", () => {
+    it("returns price history with stats", async () => {
+      const product = {
+        id: "prod-1",
+        userId: "user-1",
+        name: "Whole Milk 1L",
+        normalizedName: "whole milk 1l",
+      };
+      const prices = [
+        createMockPrice({ id: "p1", unitPrice: 3.49, merchant: "Whole Foods" }),
+        createMockPrice({ id: "p2", unitPrice: 2.99, merchant: "Trader Joes" }),
+        createMockPrice({ id: "p3", unitPrice: 3.99, merchant: "Whole Foods" }),
+      ];
+
+      mockProductModel.findFirst.mockResolvedValue(product);
+      mockProductPriceModel.findMany.mockResolvedValue(prices);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/prod-1/prices"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "prod-1" }),
+      });
+      const { status, data } = await parseResponse<{
+        product: { id: string; name: string };
+        prices: unknown[];
+        stats: {
+          count: number;
+          avgPrice: number;
+          minPrice: number;
+          maxPrice: number;
+          merchantCount: number;
+          merchants: string[];
+        };
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.product.id).toBe("prod-1");
+      expect(data.product.name).toBe("Whole Milk 1L");
+      expect(data.prices).toHaveLength(3);
+      expect(data.stats.count).toBe(3);
+      expect(data.stats.minPrice).toBe(2.99);
+      expect(data.stats.maxPrice).toBe(3.99);
+      expect(data.stats.merchantCount).toBe(2);
+      expect(data.stats.merchants).toContain("Whole Foods");
+      expect(data.stats.merchants).toContain("Trader Joes");
+    });
+
+    it("returns empty stats when no prices", async () => {
+      const product = {
+        id: "prod-1",
+        userId: "user-1",
+        name: "Whole Milk 1L",
+        normalizedName: "whole milk 1l",
+      };
+
+      mockProductModel.findFirst.mockResolvedValue(product);
+      mockProductPriceModel.findMany.mockResolvedValue([]);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/prod-1/prices"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "prod-1" }),
+      });
+      const { status, data } = await parseResponse<{
+        stats: { count: number; avgPrice: number };
+      }>(res);
+
+      expect(status).toBe(200);
+      expect(data.stats.count).toBe(0);
+      expect(data.stats.avgPrice).toBe(0);
+    });
+
+    it("filters by merchant query param", async () => {
+      const product = {
+        id: "prod-1",
+        userId: "user-1",
+        name: "Whole Milk 1L",
+        normalizedName: "whole milk 1l",
+      };
+
+      mockProductModel.findFirst.mockResolvedValue(product);
+      mockProductPriceModel.findMany.mockResolvedValue([]);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/prod-1/prices?merchant=Whole%20Foods"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "prod-1" }),
+      });
+
+      expect(mockProductPriceModel.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            productId: "prod-1",
+            merchant: "Whole Foods",
+          },
+        })
+      );
+    });
+
+    it("returns 404 for non-existent product", async () => {
+      mockProductModel.findFirst.mockResolvedValue(null);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/nonexistent/prices"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "nonexistent" }),
+      });
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(404);
+      expect(data.error).toBe("Product not found");
+    });
+
+    it("returns 404 for product belonging to another user", async () => {
+      // findFirst with userId filter returns null for other users' products
+      mockProductModel.findFirst.mockResolvedValue(null);
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/prod-other/prices"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "prod-other" }),
+      });
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(404);
+      expect(mockProductModel.findFirst).toHaveBeenCalledWith({
+        where: { id: "prod-other", userId: "user-1" },
+      });
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const { requireApiUser } = await import("@/lib/auth");
+      vi.mocked(requireApiUser).mockResolvedValueOnce({
+        user: null as never,
+        error: true as never,
+      });
+
+      const req = createRequest(
+        "http://localhost:3000/api/products/prod-1/prices"
+      );
+      const res = await getProductPrices(req, {
+        params: Promise.resolve({ id: "prod-1" }),
+      });
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(401);
+    });
+  });
+});

--- a/src/app/api/__tests__/settings.test.ts
+++ b/src/app/api/__tests__/settings.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests for /api/settings routes.
+ * Tests GET (read settings) and PATCH (update settings) endpoints.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUser, mockUserModel } = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockUserModel: createModel(),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: mockUserModel,
+  },
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────────
+
+import { GET, PATCH } from "../settings/route";
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("/api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/settings", () => {
+    it("returns user settings", async () => {
+      mockUserModel.findUnique.mockResolvedValue({
+        reminderDays: 3,
+        baseCurrency: "EUR",
+      });
+
+      const req = createRequest("http://localhost:3000/api/settings");
+      const res = await GET();
+      const { status, data } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(data).toEqual({
+        reminderDays: 3,
+        baseCurrency: "EUR",
+      });
+      expect(mockUserModel.findUnique).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        select: { reminderDays: true, baseCurrency: true },
+      });
+    });
+
+    it("returns defaults when user has no settings", async () => {
+      mockUserModel.findUnique.mockResolvedValue(null);
+
+      const res = await GET();
+      const { status, data } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(data).toEqual({
+        reminderDays: null,
+        baseCurrency: "USD",
+      });
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const { requireApiUser } = await import("@/lib/auth");
+      vi.mocked(requireApiUser).mockResolvedValueOnce({
+        user: null as never,
+        error: true as never,
+      });
+
+      const res = await GET();
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(401);
+      expect(data.error).toBe("Unauthorized");
+    });
+  });
+
+  describe("PATCH /api/settings", () => {
+    it("updates reminderDays", async () => {
+      mockUserModel.update.mockResolvedValue({ id: "user-1" });
+
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: 5 },
+      });
+      const res = await PATCH(req);
+      const { status, data } = await parseResponse<{ success: boolean }>(res);
+
+      expect(status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(mockUserModel.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { reminderDays: 5 },
+      });
+    });
+
+    it("clears reminderDays when set to null", async () => {
+      mockUserModel.update.mockResolvedValue({ id: "user-1" });
+
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: null },
+      });
+      const res = await PATCH(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(mockUserModel.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { reminderDays: null },
+      });
+    });
+
+    it("rejects invalid reminderDays (zero)", async () => {
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: 0 },
+      });
+      const res = await PATCH(req);
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("positive integer");
+    });
+
+    it("rejects invalid reminderDays (negative)", async () => {
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: -3 },
+      });
+      const res = await PATCH(req);
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("positive integer");
+    });
+
+    it("updates baseCurrency", async () => {
+      mockUserModel.update.mockResolvedValue({ id: "user-1" });
+
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { baseCurrency: "eur" },
+      });
+      const res = await PATCH(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(mockUserModel.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { baseCurrency: "EUR" },
+      });
+    });
+
+    it("rejects invalid baseCurrency (too long)", async () => {
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { baseCurrency: "ABCD" },
+      });
+      const res = await PATCH(req);
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("3-letter");
+    });
+
+    it("rejects invalid baseCurrency (too short)", async () => {
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { baseCurrency: "AB" },
+      });
+      const res = await PATCH(req);
+      const { status, data } = await parseResponse<{ error: string }>(res);
+
+      expect(status).toBe(400);
+      expect(data.error).toContain("3-letter");
+    });
+
+    it("updates both fields at once", async () => {
+      mockUserModel.update.mockResolvedValue({ id: "user-1" });
+
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: 7, baseCurrency: "GBP" },
+      });
+      const res = await PATCH(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(mockUserModel.update).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { reminderDays: 7, baseCurrency: "GBP" },
+      });
+    });
+
+    it("does not call update when no fields provided", async () => {
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: {},
+      });
+      const res = await PATCH(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(200);
+      expect(mockUserModel.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const { requireApiUser } = await import("@/lib/auth");
+      vi.mocked(requireApiUser).mockResolvedValueOnce({
+        user: null as never,
+        error: true as never,
+      });
+
+      const req = createRequest("http://localhost:3000/api/settings", {
+        method: "PATCH",
+        body: { reminderDays: 5 },
+      });
+      const res = await PATCH(req);
+      const { status } = await parseResponse(res);
+
+      expect(status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 34 new integration tests for previously untested API routes
- **Settings API** (13 tests): GET/PATCH with validation for reminderDays and baseCurrency
- **Products API** (12 tests): list with search/pagination, price history with stats, merchant filtering
- **Net-worth API** (9 tests): multi-currency conversion, exchange rate failure handling, aggregation

Test suite: 343 → 377 tests, all passing.

Closes #150

## Test plan
- [x] All 377 tests pass (`npx vitest run`)
- [x] Lint clean (no errors)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)