### PR TITLE
test: add integration tests for auth, categorize, and balance-history APIs

### DIFF
--- a/src/app/api/__tests__/auth.test.ts
+++ b/src/app/api/__tests__/auth.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Integration tests for /api/auth routes.
+ * Tests logout, register/options, register/verify, login/options, login/verify.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────
+
+const {
+  mockUserModel,
+  mockCredentialModel,
+  mockSessionModel,
+  mockDestroySession,
+  mockCreateSession,
+  mockGenerateRegistrationOptions,
+  mockVerifyRegistrationResponse,
+  mockGenerateAuthenticationOptions,
+  mockVerifyAuthenticationResponse,
+  mockDbTransaction,
+} = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUserModel: createModel(),
+    mockCredentialModel: createModel(),
+    mockSessionModel: createModel(),
+    mockDestroySession: vi.fn().mockResolvedValue(undefined),
+    mockCreateSession: vi.fn().mockResolvedValue("session-token-123"),
+    mockGenerateRegistrationOptions: vi.fn().mockResolvedValue({
+      challenge: "test-challenge-abc",
+      rp: { name: "CoinKeeper", id: "localhost" },
+      user: { id: "user-id", name: "test@example.com", displayName: "Test" },
+      pubKeyCredParams: [],
+    }),
+    mockVerifyRegistrationResponse: vi.fn().mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: new Uint8Array([1, 2, 3]),
+          publicKey: new Uint8Array([4, 5, 6]),
+          counter: 0,
+        },
+      },
+    }),
+    mockGenerateAuthenticationOptions: vi.fn().mockResolvedValue({
+      challenge: "test-auth-challenge-xyz",
+      rpId: "localhost",
+      allowCredentials: [],
+    }),
+    mockVerifyAuthenticationResponse: vi.fn().mockResolvedValue({
+      verified: true,
+      authenticationInfo: {
+        newCounter: 1,
+      },
+    }),
+    mockDbTransaction: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/session", () => ({
+  destroySession: mockDestroySession,
+  createSession: mockCreateSession,
+}));
+
+vi.mock("@/lib/webauthn", () => ({
+  getWebAuthnConfig: () => ({
+    rpName: "CoinKeeper",
+    rpID: "localhost",
+    origin: "http://localhost:3000",
+  }),
+}));
+
+vi.mock("@simplewebauthn/server", () => ({
+  generateRegistrationOptions: mockGenerateRegistrationOptions,
+  verifyRegistrationResponse: mockVerifyRegistrationResponse,
+  generateAuthenticationOptions: mockGenerateAuthenticationOptions,
+  verifyAuthenticationResponse: mockVerifyAuthenticationResponse,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: mockUserModel,
+    credential: mockCredentialModel,
+    session: mockSessionModel,
+    $transaction: mockDbTransaction,
+  },
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────
+
+import { POST as logoutPOST } from "../auth/logout/route";
+import { POST as registerOptionsPOST } from "../auth/register/options/route";
+import { POST as registerVerifyPOST } from "../auth/register/verify/route";
+import { POST as loginOptionsPOST } from "../auth/login/options/route";
+import { POST as loginVerifyPOST } from "../auth/login/verify/route";
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/auth/logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("destroys the session and returns success", async () => {
+    const res = await logoutPOST();
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockDestroySession).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 if session destruction fails", async () => {
+    mockDestroySession.mockRejectedValueOnce(new Error("DB error"));
+
+    const res = await logoutPOST();
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(500);
+    expect(data.error).toBe("Failed to log out");
+  });
+});
+
+describe("POST /api/auth/register/options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserModel.findUnique.mockResolvedValue(null); // No existing user
+  });
+
+  it("generates registration options for a new user", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/options", {
+      method: "POST",
+      body: { name: "Test User", email: "test@example.com" },
+    });
+
+    const res = await registerOptionsPOST(req);
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("challenge", "test-challenge-abc");
+    expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpName: "CoinKeeper",
+        rpID: "localhost",
+        userName: "test@example.com",
+        userDisplayName: "Test User",
+      })
+    );
+
+    // Verify cookies are set
+    const cookies = res.headers.getSetCookie();
+    const challengeCookie = cookies.find((c: string) => c.includes("ck_reg_challenge"));
+    const userCookie = cookies.find((c: string) => c.includes("ck_reg_user"));
+    expect(challengeCookie).toBeDefined();
+    expect(userCookie).toBeDefined();
+  });
+
+  it("returns 409 if email already exists", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce({
+      id: "existing-user",
+      email: "test@example.com",
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/register/options", {
+      method: "POST",
+      body: { name: "Test User", email: "test@example.com" },
+    });
+
+    const res = await registerOptionsPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(409);
+    expect(data.error).toContain("already exists");
+  });
+
+  it("returns 400 for missing name", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/options", {
+      method: "POST",
+      body: { email: "test@example.com" },
+    });
+
+    const res = await registerOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/options", {
+      method: "POST",
+      body: { name: "Test", email: "not-an-email" },
+    });
+
+    const res = await registerOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for empty name", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/options", {
+      method: "POST",
+      body: { name: "", email: "test@example.com" },
+    });
+
+    const res = await registerOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+});
+
+describe("POST /api/auth/register/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserModel.create.mockResolvedValue({
+      id: "new-user-1",
+      name: "Test User",
+      email: "test@example.com",
+    });
+  });
+
+  it("returns 400 if registration cookies are missing", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+    });
+
+    const res = await registerVerifyPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("expired");
+  });
+
+  it("returns 400 if verification fails", async () => {
+    mockVerifyRegistrationResponse.mockResolvedValueOnce({
+      verified: false,
+      registrationInfo: null,
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/register/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+      headers: {
+        Cookie:
+          "ck_reg_challenge=test-challenge; ck_reg_user=" +
+          encodeURIComponent(JSON.stringify({ name: "Test", email: "test@example.com" })),
+      },
+    });
+
+    const res = await registerVerifyPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("verification failed");
+  });
+
+  it("creates user and session on successful verification", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/register/verify", {
+      method: "POST",
+      body: {
+        id: "cred-id",
+        response: { transports: ["internal"] },
+      },
+      headers: {
+        Cookie:
+          "ck_reg_challenge=test-challenge; ck_reg_user=" +
+          encodeURIComponent(JSON.stringify({ name: "Test User", email: "test@example.com" })),
+      },
+    });
+
+    const res = await registerVerifyPOST(req);
+    const { status, data } = await parseResponse<{ success: boolean; userId: string }>(res);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.userId).toBe("new-user-1");
+    expect(mockUserModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: "Test User",
+          email: "test@example.com",
+        }),
+      })
+    );
+    expect(mockCreateSession).toHaveBeenCalledWith("new-user-1");
+  });
+});
+
+describe("POST /api/auth/login/options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("generates authentication options for existing user", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce({
+      id: "user-1",
+      email: "test@example.com",
+      credentials: [
+        {
+          credentialId: "Y3JlZC0x",
+          transports: JSON.stringify(["internal"]),
+        },
+      ],
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "test@example.com" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("challenge", "test-auth-challenge-xyz");
+    expect(mockGenerateAuthenticationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpID: "localhost",
+        userVerification: "preferred",
+      })
+    );
+
+    // Verify cookies are set
+    const cookies = res.headers.getSetCookie();
+    const challengeCookie = cookies.find((c: string) => c.includes("ck_auth_challenge"));
+    const userCookie = cookies.find((c: string) => c.includes("ck_auth_user"));
+    expect(challengeCookie).toBeDefined();
+    expect(userCookie).toBeDefined();
+  });
+
+  it("returns 404 if user not found", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce(null);
+
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "nobody@example.com" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(404);
+    expect(data.error).toContain("No account found");
+  });
+
+  it("returns 404 if user has no credentials", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce({
+      id: "user-1",
+      email: "test@example.com",
+      credentials: [],
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "test@example.com" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(404);
+    expect(data.error).toContain("No account found");
+  });
+
+  it("returns 400 for missing email", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: {},
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for invalid email format", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "not-valid" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("handles credentials with malformed transports JSON", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce({
+      id: "user-1",
+      email: "test@example.com",
+      credentials: [
+        {
+          credentialId: "Y3JlZC0x",
+          transports: "not-valid-json",
+        },
+      ],
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "test@example.com" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    // Should still succeed — malformed transports gracefully fallback to undefined
+    expect(status).toBe(200);
+  });
+
+  it("handles credentials with null transports", async () => {
+    mockUserModel.findUnique.mockResolvedValueOnce({
+      id: "user-1",
+      email: "test@example.com",
+      credentials: [
+        {
+          credentialId: "Y3JlZC0x",
+          transports: null,
+        },
+      ],
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/options", {
+      method: "POST",
+      body: { email: "test@example.com" },
+    });
+
+    const res = await loginOptionsPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(200);
+  });
+});
+
+describe("POST /api/auth/login/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 if auth cookies are missing", async () => {
+    const req = createRequest("http://localhost:3000/api/auth/login/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+    });
+
+    const res = await loginVerifyPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("expired");
+  });
+
+  it("returns 400 if credential not found", async () => {
+    mockCredentialModel.findFirst.mockResolvedValueOnce(null);
+
+    const req = createRequest("http://localhost:3000/api/auth/login/verify", {
+      method: "POST",
+      body: { id: "unknown-cred", response: {} },
+      headers: {
+        Cookie: "ck_auth_challenge=test-challenge; ck_auth_user=user-1",
+      },
+    });
+
+    const res = await loginVerifyPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("Credential not found");
+  });
+
+  it("returns 400 if verification fails", async () => {
+    mockCredentialModel.findFirst.mockResolvedValueOnce({
+      id: "cred-db-id",
+      userId: "user-1",
+      credentialId: "cred-id",
+      publicKey: Buffer.from([4, 5, 6]),
+      counter: BigInt(0),
+      transports: null,
+    });
+
+    mockVerifyAuthenticationResponse.mockResolvedValueOnce({
+      verified: false,
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+      headers: {
+        Cookie: "ck_auth_challenge=test-challenge; ck_auth_user=user-1",
+      },
+    });
+
+    const res = await loginVerifyPOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("verification failed");
+  });
+
+  it("creates session and clears cookies on successful login", async () => {
+    mockCredentialModel.findFirst.mockResolvedValueOnce({
+      id: "cred-db-id",
+      userId: "user-1",
+      credentialId: "cred-id",
+      publicKey: Buffer.from([4, 5, 6]),
+      counter: BigInt(0),
+      transports: JSON.stringify(["internal"]),
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+      headers: {
+        Cookie: "ck_auth_challenge=test-challenge; ck_auth_user=user-1",
+      },
+    });
+
+    const res = await loginVerifyPOST(req);
+    const { status, data } = await parseResponse<{ success: boolean }>(res);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify credential counter was updated
+    expect(mockCredentialModel.update).toHaveBeenCalledWith({
+      where: { id: "cred-db-id" },
+      data: { counter: BigInt(1) },
+    });
+
+    // Verify session was created
+    expect(mockCreateSession).toHaveBeenCalledWith("user-1");
+  });
+
+  it("handles credentials with malformed transports JSON", async () => {
+    mockCredentialModel.findFirst.mockResolvedValueOnce({
+      id: "cred-db-id",
+      userId: "user-1",
+      credentialId: "cred-id",
+      publicKey: Buffer.from([4, 5, 6]),
+      counter: BigInt(0),
+      transports: "invalid-json",
+    });
+
+    const req = createRequest("http://localhost:3000/api/auth/login/verify", {
+      method: "POST",
+      body: { id: "cred-id", response: {} },
+      headers: {
+        Cookie: "ck_auth_challenge=test-challenge; ck_auth_user=user-1",
+      },
+    });
+
+    const res = await loginVerifyPOST(req);
+    const { status } = await parseResponse(res);
+
+    // Should still succeed — transports fallback to undefined
+    expect(status).toBe(200);
+  });
+});

--- a/src/app/api/__tests__/balance-history.test.ts
+++ b/src/app/api/__tests__/balance-history.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for /api/analytics/balance-history route.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────
+
+const { mockUser, mockAccountModel, mockTransactionModel } = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockAccountModel: createModel(),
+    mockTransactionModel: createModel(),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+}));
+
+vi.mock("@/lib/space-context", () => ({
+  getSpaceContext: vi
+    .fn()
+    .mockResolvedValue({ spaceId: null, spaceName: null, role: null }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    account: mockAccountModel,
+    transaction: mockTransactionModel,
+  },
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────
+
+import { GET } from "../analytics/balance-history/route";
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/analytics/balance-history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty data when user has no accounts", async () => {
+    mockAccountModel.findMany.mockResolvedValue([]);
+
+    const req = createRequest("http://localhost:3000/api/analytics/balance-history");
+    const res = await GET(req);
+    const { status, data } = await parseResponse<{ data: unknown[]; accounts: unknown[]; currency: string }>(res);
+
+    expect(status).toBe(200);
+    expect(data.data).toEqual([]);
+    expect(data.accounts).toEqual([]);
+    expect(data.currency).toBe("USD");
+  });
+
+  it("returns balance history with transactions", async () => {
+    const accounts = [
+      { id: "acc-1", name: "Checking", currency: "USD", balance: 500 },
+    ];
+    mockAccountModel.findMany.mockResolvedValue(accounts);
+
+    const transactions = [
+      { type: "income", amount: 1000, toAmount: null, date: new Date("2026-03-01"), fromAccountId: null, toAccountId: "acc-1" },
+      { type: "expense", amount: 200, toAmount: null, date: new Date("2026-03-05"), fromAccountId: "acc-1", toAccountId: null },
+    ];
+
+    // Filtered transactions (same as all since no date filter)
+    mockTransactionModel.findMany
+      .mockResolvedValueOnce(transactions)  // filtered
+      .mockResolvedValueOnce(transactions); // all transactions
+
+    const req = createRequest("http://localhost:3000/api/analytics/balance-history");
+    const res = await GET(req);
+    const { status, data } = await parseResponse<{ data: { date: string; total: number }[]; accounts: unknown[]; currency: string }>(res);
+
+    expect(status).toBe(200);
+    expect(data.data.length).toBeGreaterThan(0);
+    expect(data.accounts).toEqual([{ id: "acc-1", name: "Checking", currency: "USD" }]);
+    expect(data.currency).toBe("USD");
+  });
+
+  it("filters by accountId query parameter", async () => {
+    const accounts = [
+      { id: "acc-1", name: "Checking", currency: "USD", balance: 500 },
+    ];
+    mockAccountModel.findMany.mockResolvedValue(accounts);
+    mockTransactionModel.findMany.mockResolvedValue([]);
+
+    const req = createRequest("http://localhost:3000/api/analytics/balance-history?accountId=acc-1");
+    await GET(req);
+
+    expect(mockAccountModel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "acc-1",
+          userId: "user-1",
+        }),
+      })
+    );
+  });
+
+  it("uses primary currency from accounts", async () => {
+    const accounts = [
+      { id: "acc-1", name: "Account 1", currency: "EUR", balance: 100 },
+      { id: "acc-2", name: "Account 2", currency: "EUR", balance: 200 },
+      { id: "acc-3", name: "Account 3", currency: "USD", balance: 50 },
+    ];
+    mockAccountModel.findMany.mockResolvedValue(accounts);
+    mockTransactionModel.findMany.mockResolvedValue([]);
+
+    const req = createRequest("http://localhost:3000/api/analytics/balance-history");
+    const res = await GET(req);
+    const { data } = await parseResponse<{ currency: string }>(res);
+
+    expect(data.currency).toBe("EUR");
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const { requireApiUser } = await import("@/lib/auth");
+    vi.mocked(requireApiUser).mockResolvedValueOnce({
+      user: null as never,
+      error: true,
+    });
+
+    const req = createRequest("http://localhost:3000/api/analytics/balance-history");
+    const res = await GET(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(401);
+  });
+
+  it("handles date range filters", async () => {
+    const accounts = [
+      { id: "acc-1", name: "Checking", currency: "USD", balance: 500 },
+    ];
+    mockAccountModel.findMany.mockResolvedValue(accounts);
+    mockTransactionModel.findMany.mockResolvedValue([]);
+
+    const req = createRequest(
+      "http://localhost:3000/api/analytics/balance-history?from=2026-03-01&to=2026-03-31"
+    );
+    await GET(req);
+
+    // Verify filtered transactions query includes date filter
+    expect(mockTransactionModel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          date: {
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          },
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/__tests__/categorize.test.ts
+++ b/src/app/api/__tests__/categorize.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Integration tests for /api/categorize and /api/categorize/feedback routes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRequest, parseResponse } from "./helpers";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────
+
+const {
+  mockUser,
+  mockCategoryModel,
+  mockCategoryCorrectionModel,
+  mockCategorizeTransaction,
+  mockFindSimilar,
+  mockNormalizeName,
+} = vi.hoisted(() => {
+  const createModel = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+    deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+    count: vi.fn().mockResolvedValue(0),
+  });
+
+  return {
+    mockUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      reminderDays: null,
+      baseCurrency: "USD",
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    },
+    mockCategoryModel: createModel(),
+    mockCategoryCorrectionModel: createModel(),
+    mockCategorizeTransaction: vi.fn().mockResolvedValue({
+      categoryId: "cat-1",
+      suggestedName: "Food & Dining",
+      confidence: 0.9,
+      isNew: false,
+    }),
+    mockFindSimilar: vi.fn().mockReturnValue(null),
+    mockNormalizeName: vi.fn((name: string) => name.trim().toLowerCase()),
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  requireApiUser: vi.fn().mockResolvedValue({ user: mockUser, error: false }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    category: mockCategoryModel,
+    categoryCorrection: mockCategoryCorrectionModel,
+  },
+}));
+
+vi.mock("@/lib/categorize", () => ({
+  categorizeTransaction: mockCategorizeTransaction,
+}));
+
+vi.mock("@/lib/category-normalize", () => ({
+  findSimilar: mockFindSimilar,
+  normalizeName: mockNormalizeName,
+}));
+
+// ── Import handlers after mocking ────────────────────────────────────────
+
+import { POST as categorizePOST } from "../categorize/route";
+import { POST as feedbackPOST } from "../categorize/feedback/route";
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/categorize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: user has some categories
+    mockCategoryModel.findMany.mockResolvedValue([
+      { id: "cat-1", name: "Food & Dining" },
+      { id: "cat-2", name: "Transport" },
+    ]);
+    mockCategoryCorrectionModel.findMany.mockResolvedValue([]);
+  });
+
+  it("returns AI categorization result for valid description", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "Coffee at Starbucks", amount: 5.5 },
+    });
+
+    const res = await categorizePOST(req);
+    const { status, data } = await parseResponse(res);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      categoryId: "cat-1",
+      suggestedName: "Food & Dining",
+      confidence: 0.9,
+      isNew: false,
+    });
+    expect(mockCategorizeTransaction).toHaveBeenCalledWith(
+      "Coffee at Starbucks",
+      expect.any(Array),
+      5.5,
+      undefined
+    );
+  });
+
+  it("returns 400 for missing description", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { amount: 5 },
+    });
+
+    const res = await categorizePOST(req);
+    const { status, data } = await parseResponse<{ error: string }>(res);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("Description is required");
+  });
+
+  it("returns 400 for empty description", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "   " },
+    });
+
+    const res = await categorizePOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("seeds default categories when user has none", async () => {
+    // First call returns empty (no categories), second call returns seeded
+    mockCategoryModel.findMany
+      .mockResolvedValueOnce([]) // initial check
+      .mockResolvedValueOnce([
+        { id: "cat-new-1", name: "Food & Dining" },
+        { id: "cat-new-2", name: "Transport" },
+      ]);
+
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "Groceries" },
+    });
+
+    await categorizePOST(req);
+
+    expect(mockCategoryModel.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: "user-1", name: "Food & Dining" }),
+        ]),
+      })
+    );
+  });
+
+  it("creates new category when AI suggests a new one", async () => {
+    mockCategorizeTransaction.mockResolvedValueOnce({
+      categoryId: null,
+      suggestedName: "Pet Care",
+      confidence: 0.7,
+      isNew: true,
+    });
+    mockFindSimilar.mockReturnValueOnce(null);
+    mockNormalizeName.mockReturnValueOnce("pet care");
+    mockCategoryModel.create.mockResolvedValueOnce({
+      id: "cat-new",
+      name: "pet care",
+    });
+
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "Dog food" },
+    });
+
+    const res = await categorizePOST(req);
+    const { status, data } = await parseResponse<{ categoryId: string; isNew: boolean }>(res);
+
+    expect(status).toBe(200);
+    expect(data.categoryId).toBe("cat-new");
+    expect(mockCategoryModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: "user-1", name: "pet care" }),
+      })
+    );
+  });
+
+  it("uses existing similar category instead of creating duplicate", async () => {
+    mockCategorizeTransaction.mockResolvedValueOnce({
+      categoryId: null,
+      suggestedName: "Food",
+      confidence: 0.7,
+      isNew: true,
+    });
+    mockFindSimilar.mockReturnValueOnce({ id: "cat-1", name: "Food & Dining" });
+
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "Lunch" },
+    });
+
+    const res = await categorizePOST(req);
+    const { status, data } = await parseResponse<{ categoryId: string; isNew: boolean }>(res);
+
+    expect(status).toBe(200);
+    expect(data.categoryId).toBe("cat-1");
+    expect(data.isNew).toBe(false);
+    expect(mockCategoryModel.create).not.toHaveBeenCalled();
+  });
+
+  it("passes corrections to AI when available", async () => {
+    const corrections = [
+      { id: "corr-1", description: "uber", suggestedCategoryId: "cat-1", correctedCategoryId: "cat-2" },
+    ];
+    mockCategoryCorrectionModel.findMany.mockResolvedValueOnce(corrections);
+
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "Uber ride" },
+    });
+
+    await categorizePOST(req);
+
+    expect(mockCategorizeTransaction).toHaveBeenCalledWith(
+      "Uber ride",
+      expect.any(Array),
+      undefined,
+      corrections
+    );
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const { requireApiUser } = await import("@/lib/auth");
+    vi.mocked(requireApiUser).mockResolvedValueOnce({
+      user: null as never,
+      error: true,
+    });
+
+    const req = createRequest("http://localhost:3000/api/categorize", {
+      method: "POST",
+      body: { description: "test" },
+    });
+
+    const res = await categorizePOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(401);
+  });
+});
+
+describe("POST /api/categorize/feedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCategoryCorrectionModel.create.mockResolvedValue({
+      id: "corr-1",
+      userId: "user-1",
+      description: "test",
+      suggestedCategoryId: "cat-1",
+      correctedCategoryId: "cat-2",
+    });
+  });
+
+  it("stores correction when user changes category", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: {
+        description: "Uber ride",
+        suggestedCategoryId: "cat-1",
+        correctedCategoryId: "cat-2",
+      },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status, data } = await parseResponse<{ stored: boolean; id: string }>(res);
+
+    expect(status).toBe(200);
+    expect(data.stored).toBe(true);
+    expect(data.id).toBe("corr-1");
+    expect(mockCategoryCorrectionModel.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        description: "Uber ride",
+        suggestedCategoryId: "cat-1",
+        correctedCategoryId: "cat-2",
+      },
+    });
+  });
+
+  it("skips storage when no correction needed (same category)", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: {
+        description: "Coffee",
+        suggestedCategoryId: "cat-1",
+        correctedCategoryId: "cat-1",
+      },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status, data } = await parseResponse<{ stored: boolean; reason: string }>(res);
+
+    expect(status).toBe(200);
+    expect(data.stored).toBe(false);
+    expect(data.reason).toBe("no correction needed");
+    expect(mockCategoryCorrectionModel.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for missing description", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: { suggestedCategoryId: "cat-1", correctedCategoryId: "cat-2" },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for missing correctedCategoryId", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: { description: "test", suggestedCategoryId: "cat-1" },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(400);
+  });
+
+  it("handles null suggestedCategoryId", async () => {
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: {
+        description: "new item",
+        suggestedCategoryId: null,
+        correctedCategoryId: "cat-2",
+      },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status, data } = await parseResponse<{ stored: boolean }>(res);
+
+    expect(status).toBe(200);
+    expect(data.stored).toBe(true);
+    expect(mockCategoryCorrectionModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ suggestedCategoryId: null }),
+      })
+    );
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const { requireApiUser } = await import("@/lib/auth");
+    vi.mocked(requireApiUser).mockResolvedValueOnce({
+      user: null as never,
+      error: true,
+    });
+
+    const req = createRequest("http://localhost:3000/api/categorize/feedback", {
+      method: "POST",
+      body: {
+        description: "test",
+        suggestedCategoryId: "cat-1",
+        correctedCategoryId: "cat-2",
+      },
+    });
+
+    const res = await feedbackPOST(req);
+    const { status } = await parseResponse(res);
+
+    expect(status).toBe(401);
+  });
+});

--- a/src/app/api/__tests__/products.test.ts
+++ b/src/app/api/__tests__/products.test.ts
@@ -145,7 +145,7 @@ describe("/api/products", () => {
       mockProductModel.count.mockResolvedValue(0);
 
       const req = createRequest("http://localhost:3000/api/products?q=milk");
-      const res = await listProducts(req);
+      await listProducts(req);
 
       expect(mockProductModel.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -296,7 +296,7 @@ describe("/api/products", () => {
       const req = createRequest(
         "http://localhost:3000/api/products/prod-1/prices?merchant=Whole%20Foods"
       );
-      const res = await getProductPrices(req, {
+      await getProductPrices(req, {
         params: Promise.resolve({ id: "prod-1" }),
       });
 

--- a/src/app/api/__tests__/settings.test.ts
+++ b/src/app/api/__tests__/settings.test.ts
@@ -61,7 +61,7 @@ describe("/api/settings", () => {
         baseCurrency: "EUR",
       });
 
-      const req = createRequest("http://localhost:3000/api/settings");
+      createRequest("http://localhost:3000/api/settings");
       const res = await GET();
       const { status, data } = await parseResponse(res);
 


### PR DESCRIPTION
## Summary
- Add **22 auth tests**: logout, register/options, register/verify, login/options, login/verify — WebAuthn cookie flows, validation, error paths
- Add **14 categorize tests**: AI categorization, default category seeding, dedup via similar match, correction feedback storage
- Add **6 balance-history tests**: date filtering, accountId filter, multi-currency primary detection, empty states
- Fix 3 lint warnings in existing test files (unused variables in products.test.ts and settings.test.ts)

Test suite: 377 → **419 tests**, all passing. Lint clean. Build clean.

Closes #152

## Test plan
- [x] All 419 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)